### PR TITLE
Potential fix for code scanning alert no. 22: Log entries created from user input

### DIFF
--- a/DotNetTwitchBot/Circuit/CircuitUserService.cs
+++ b/DotNetTwitchBot/Circuit/CircuitUserService.cs
@@ -60,7 +60,8 @@ namespace DotNetTwitchBot.Circuit
             {
                 Circuits[CircuitId].LastPage = uri;
                 Circuits[CircuitId].LastSeen = DateTime.Now;
-                logger.LogInformation("{UserId} navigated to {Uri}.", Circuits[CircuitId].UserId, uri);
+                var sanitizedUri = uri.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                logger.LogInformation("{UserId} navigated to {Uri}.", Circuits[CircuitId].UserId, sanitizedUri);
                 OnCircuitsChanged();
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Psychoboy/PenguinTwitchBot/security/code-scanning/22](https://github.com/Psychoboy/PenguinTwitchBot/security/code-scanning/22)

To fix the problem, we need to sanitize the `uri` parameter before logging it. Since the log entries are plain text, we should remove any newline characters from the `uri` to prevent log forging. This can be done using the `String.Replace` method to replace newline characters with an empty string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
