### PR TITLE
Adds ability for certain equipment to snap

### DIFF
--- a/DotNetTwitchBot.Test/Bot/Commands/Fishing/FishingShopServiceTests.cs
+++ b/DotNetTwitchBot.Test/Bot/Commands/Fishing/FishingShopServiceTests.cs
@@ -282,30 +282,6 @@ namespace DotNetTwitchBot.Test.Bot.Commands.Fishing
         }
 
         [Fact]
-        public async Task GenerateDefaultShopItems_WithFishTypes_CreatesSpecificBoosts()
-        {
-            // Arrange - Add rare fish types (specific items only created for Rare+)
-            var fishTypes = new List<FishType>
-            {
-                new() { Id = 1, Name = "Rare Salmon", Rarity = FishRarity.Rare, Enabled = true, BaseWeight = 20, BaseGold = 200 },
-                new() { Id = 2, Name = "Epic Tuna", Rarity = FishRarity.Epic, Enabled = true, BaseWeight = 50, BaseGold = 500 }
-            };
-            _context.FishTypes.AddRange(fishTypes);
-            await _context.SaveChangesAsync();
-
-            // Act
-            var itemCount = await _shopService.GenerateDefaultShopItems();
-
-            // Assert
-            Assert.True(itemCount > 0);
-            var items = await _shopService.GetAllShopItems();
-
-            // Verify fish-specific items were created (GenerateDefaultShopItems creates items for Rare+ fish)
-            Assert.Contains(items, i => i.Name.Contains("Salmon") && i.BoostType == FishingBoostType.SpecificFishBoost);
-            Assert.Contains(items, i => i.Name.Contains("Tuna") && i.BoostType == FishingBoostType.SpecificFishBoost);
-        }
-
-        [Fact]
         public async Task GenerateDefaultShopItems_Idempotent_DoesNotDuplicate()
         {
             // Act - Run twice

--- a/DotNetTwitchBot/Bot/Actions/SubActions/Handlers/FishingHandler.cs
+++ b/DotNetTwitchBot/Bot/Actions/SubActions/Handlers/FishingHandler.cs
@@ -1,5 +1,6 @@
 using DotNetTwitchBot.Bot.Actions.SubActions.Types;
 using DotNetTwitchBot.Bot.Commands.Fishing;
+using DotNetTwitchBot.Bot.Models.Fishing;
 using DotNetTwitchBot.Bot.Notifications;
 using DotNetTwitchBot.Bot.Queues;
 using System.Collections.Concurrent;
@@ -64,7 +65,52 @@ namespace DotNetTwitchBot.Bot.Actions.SubActions.Handlers
             {
                 try
                 {
-                    var fishCatch = await _fishingGameplayService.PerformFishingAttempt(userId, username);
+                    var attemptResult = await _fishingGameplayService.PerformFishingAttempt(userId, username);
+
+                    if (attemptResult.Outcome == FishingAttemptOutcome.LineSnapped ||
+                        attemptResult.Outcome == FishingAttemptOutcome.RodSnapped)
+                    {
+                        var isRodSnap = attemptResult.Outcome == FishingAttemptOutcome.RodSnapped;
+                        var failText = isRodSnap ? "ROD SNAPPED" : "LINE SNAPPED";
+
+                        var snappedMessage = new
+                        {
+                            fishing = new
+                            {
+                                username = username,
+                                fishName = failText,
+                                rarity = "Accident",
+                                stars = 0,
+                                weight = 0.0,
+                                gold = 0,
+                                imageFileName = "",
+                                lineSnapped = true,
+                                rodSnapped = isRodSnap,
+                                duration = settings.DisplayDurationMs
+                            }
+                        };
+
+                        await _webSocketMessenger.AddToQueue(JsonSerializer.Serialize(snappedMessage));
+
+                        if (attempts > 1 && i < attempts - 1)
+                        {
+                            await Task.Delay(settings.DisplayDurationMs + 500);
+                        }
+
+                        _logger.LogInformation("User {Username} had a snapped {SnapType} and caught nothing", username, isRodSnap ? "rod" : "line");
+                        variables["fish_type"] = failText;
+                        variables["fish_rarity"] = "Accident";
+                        variables["fish_stars"] = "0";
+                        variables["fish_weight"] = "0";
+                        variables["fish_gold"] = "0";
+                        continue;
+                    }
+
+                    var fishCatch = attemptResult.FishCatch;
+                    if (fishCatch == null)
+                    {
+                        throw new InvalidOperationException("Fishing attempt completed without catch data.");
+                    }
 
                     var message = new
                     {

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingAnalyticsService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingAnalyticsService.cs
@@ -85,10 +85,12 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 RarityLegendaryThreshold = settings.RarityLegendaryThreshold
             };
 
-            var lineSnapChance = settings.LineSnapChance > 0 && settings.LineSnapChance <= 1
+            var lineSnapChance = !double.IsNaN(settings.LineSnapChance) && !double.IsInfinity(settings.LineSnapChance) &&
+                settings.LineSnapChance >= 0 && settings.LineSnapChance <= 1
                 ? settings.LineSnapChance
                 : FishingSettings.DefaultLineSnapChance;
-            var rodSnapChance = settings.RodSnapChance > 0 && settings.RodSnapChance <= 1
+            var rodSnapChance = !double.IsNaN(settings.RodSnapChance) && !double.IsInfinity(settings.RodSnapChance) &&
+                settings.RodSnapChance >= 0 && settings.RodSnapChance <= 1
                 ? settings.RodSnapChance
                 : FishingSettings.DefaultRodSnapChance;
 
@@ -485,10 +487,12 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             }
 
             var settings = await _fishingService.GetSettings() ?? new FishingSettings();
-            var lineSnapChance = settings.LineSnapChance > 0 && settings.LineSnapChance <= 1
+            var lineSnapChance = !double.IsNaN(settings.LineSnapChance) && !double.IsInfinity(settings.LineSnapChance) &&
+                settings.LineSnapChance >= 0 && settings.LineSnapChance <= 1
                 ? settings.LineSnapChance
                 : FishingSettings.DefaultLineSnapChance;
-            var rodSnapChance = settings.RodSnapChance > 0 && settings.RodSnapChance <= 1
+            var rodSnapChance = !double.IsNaN(settings.RodSnapChance) && !double.IsInfinity(settings.RodSnapChance) &&
+                settings.RodSnapChance >= 0 && settings.RodSnapChance <= 1
                 ? settings.RodSnapChance
                 : FishingSettings.DefaultRodSnapChance;
             var successfulAttemptChance = (1.0 - rodSnapChance) * (1.0 - lineSnapChance);
@@ -913,10 +917,12 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             };
 
             var settings = await _fishingService.GetSettings() ?? new FishingSettings();
-            var lineSnapChance = settings.LineSnapChance > 0 && settings.LineSnapChance <= 1
+            var lineSnapChance = !double.IsNaN(settings.LineSnapChance) && !double.IsInfinity(settings.LineSnapChance) &&
+                settings.LineSnapChance >= 0 && settings.LineSnapChance <= 1
                 ? settings.LineSnapChance
                 : FishingSettings.DefaultLineSnapChance;
-            var rodSnapChance = settings.RodSnapChance > 0 && settings.RodSnapChance <= 1
+            var rodSnapChance = !double.IsNaN(settings.RodSnapChance) && !double.IsInfinity(settings.RodSnapChance) &&
+                settings.RodSnapChance >= 0 && settings.RodSnapChance <= 1
                 ? settings.RodSnapChance
                 : FishingSettings.DefaultRodSnapChance;
             var successfulAttemptChance = (1.0 - rodSnapChance) * (1.0 - lineSnapChance);

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingAnalyticsService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingAnalyticsService.cs
@@ -23,15 +23,19 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             _fishingService = fishingService;
         }
 
-        public async Task<FishingSimulationResult> SimulateFishing(int iterations, bool useBoostMode, double boostModeMultiplier, List<int> shopItemIds)
+        public async Task<FishingSimulationResult> SimulateFishing(int iterations, List<int> shopItemIds)
         {
             using var scope = _scopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
 
+            var settings = await _fishingService.GetSettings() ?? new FishingSettings();
+            var boostModeActive = settings.BoostMode;
+            var boostModeMultiplier = settings.BoostModeRarityMultiplier;
+
             var result = new FishingSimulationResult
             {
                 TotalIterations = iterations,
-                BoostModeUsed = useBoostMode,
+                BoostModeUsed = boostModeActive,
                 BoostModeMultiplier = boostModeMultiplier
             };
 
@@ -63,31 +67,37 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 ShopItemId = item.Id,
                 ShopItem = item,
                 IsEquipped = true,
-                RemainingUses = 999
+                RemainingUses = item.MaxUses ?? -1
             }).ToList();
 
             result.ItemsUsed = shopItems.Select(i => i.Name).ToList();
 
-            // Get or create settings
-            var settings = await _fishingService.GetSettings();
-            if (settings == null)
-            {
-                settings = new FishingSettings();
-            }
-
-            // Override boost mode settings for simulation
+            // Use current live settings for simulation behavior.
             var simulationSettings = new FishingSettings
             {
-                BoostMode = useBoostMode,
+                BoostMode = boostModeActive,
                 BoostModeRarityMultiplier = boostModeMultiplier,
+                LineSnapChance = settings.LineSnapChance,
+                RodSnapChance = settings.RodSnapChance,
                 RarityUncommonThreshold = settings.RarityUncommonThreshold,
                 RarityRareThreshold = settings.RarityRareThreshold,
                 RarityEpicThreshold = settings.RarityEpicThreshold,
                 RarityLegendaryThreshold = settings.RarityLegendaryThreshold
             };
 
+            var lineSnapChance = settings.LineSnapChance > 0 && settings.LineSnapChance <= 1
+                ? settings.LineSnapChance
+                : FishingSettings.DefaultLineSnapChance;
+            var rodSnapChance = settings.RodSnapChance > 0 && settings.RodSnapChance <= 1
+                ? settings.RodSnapChance
+                : FishingSettings.DefaultRodSnapChance;
+
+            result.AppliedLineSnapChance = lineSnapChance;
+            result.AppliedRodSnapChance = rodSnapChance;
+
             var totalWeight = 0.0;
             var totalGold = 0;
+            var snapReplacementCost = 0.0;
             var minWeight = double.MaxValue;
             var maxWeight = 0.0;
             var heaviestFishName = string.Empty;
@@ -95,10 +105,28 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             // Run simulations
             for (int i = 0; i < iterations; i++)
             {
+                if (Random.Shared.NextDouble() < rodSnapChance)
+                {
+                    result.RodSnapCount++;
+                    result.FailedAttempts++;
+                    snapReplacementCost += ApplyRodSnapLosses(mockBoosts);
+                    continue;
+                }
+
+                if (Random.Shared.NextDouble() < lineSnapChance)
+                {
+                    result.LineSnapCount++;
+                    result.FailedAttempts++;
+                    snapReplacementCost += ApplyLineSnapLosses(mockBoosts);
+                    continue;
+                }
+
                 var fish = FishingCalculations.SelectRandomFish(fishTypes, simulationSettings, mockBoosts);
                 var stars = FishingCalculations.CalculateStars(fish, mockBoosts);
                 var weight = FishingCalculations.CalculateWeight(fish, stars, mockBoosts);
                 var gold = FishingCalculations.CalculateGold(fish, stars, weight);
+
+                result.SuccessfulCatches++;
 
                 // Update counters
                 result.RarityCounts[fish.Rarity]++;
@@ -120,16 +148,24 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                     maxWeight = weight;
                     heaviestFishName = fish.Name;
                 }
+
+                ConsumeUsesAfterCatch(mockBoosts);
             }
 
             // Calculate statistics
             result.AverageWeight = Math.Round(totalWeight / iterations, 2);
             result.AverageGold = Math.Round((double)totalGold / iterations, 2);
             result.TotalGold = totalGold;
-            result.MinWeight = Math.Round(minWeight, 2);
-            result.MaxWeight = Math.Round(maxWeight, 2);
-            result.HeaviestFish = heaviestFishName;
-            result.MostCommonFish = result.FishCounts.OrderByDescending(kvp => kvp.Value).First().Key;
+            result.MinWeight = result.SuccessfulCatches > 0 ? Math.Round(minWeight, 2) : 0;
+            result.MaxWeight = result.SuccessfulCatches > 0 ? Math.Round(maxWeight, 2) : 0;
+            result.HeaviestFish = result.SuccessfulCatches > 0 ? heaviestFishName : "None";
+            result.MostCommonFish = result.FishCounts.Any()
+                ? result.FishCounts.OrderByDescending(kvp => kvp.Value).First().Key
+                : "None";
+            result.SnapFailureRatePercent = Math.Round((double)result.FailedAttempts / iterations * 100.0, 2);
+            result.SnapReplacementCostTotal = Math.Round(snapReplacementCost, 2);
+            result.NetGoldAfterSnapCosts = Math.Round(totalGold - snapReplacementCost, 2);
+            result.NetAverageGoldPerAttempt = Math.Round(result.NetGoldAfterSnapCosts / iterations, 2);
 
             return result;
         }
@@ -448,14 +484,63 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 return 0.0;
             }
 
-            // Define progression tiers
+            var settings = await _fishingService.GetSettings() ?? new FishingSettings();
+            var lineSnapChance = settings.LineSnapChance > 0 && settings.LineSnapChance <= 1
+                ? settings.LineSnapChance
+                : FishingSettings.DefaultLineSnapChance;
+            var rodSnapChance = settings.RodSnapChance > 0 && settings.RodSnapChance <= 1
+                ? settings.RodSnapChance
+                : FishingSettings.DefaultRodSnapChance;
+            var successfulAttemptChance = (1.0 - rodSnapChance) * (1.0 - lineSnapChance);
+
+            var shopItemCosts = await context.FishingShopItems
+                .AsNoTracking()
+                .ToDictionaryAsync(i => i.Name, i => i.Cost, StringComparer.OrdinalIgnoreCase);
+
+            var tiers = BuildProgressionTiers(targetWeeks);
+
+            var totalWeeks = tiers.Sum(t => t.Weeks);
+            double weightedGold = 0.0;
+
+            _logger.LogInformation("[PROGRESSIVE] Tier breakdown:");
+            foreach (var tier in tiers)
+            {
+                var grossTierGold = CalculateExpectedGoldWithBoosts(fishTypes, tier.RarityBoost, tier.StarBoost, tier.WeightBoost);
+                var snapReplacementCost = CalculateExpectedSnapReplacementCost(
+                    tier,
+                    shopItemCosts,
+                    lineSnapChance,
+                    rodSnapChance);
+                var tierGold = Math.Max(0.0, (grossTierGold * successfulAttemptChance) - snapReplacementCost);
+                var tierWeight = tier.Weeks / (double)totalWeeks;
+                var contribution = tierGold * tierWeight;
+                weightedGold += contribution;
+
+                _logger.LogInformation("[PROGRESSIVE]   {Name}: {Weeks}wk, gross={Gross}g, success={Success:P2}, snapSink={Sink}g => net={Net}g × {Weight:P1} = {Contribution}g", 
+                    tier.Name,
+                    tier.Weeks,
+                    Math.Round(grossTierGold, 2),
+                    successfulAttemptChance,
+                    Math.Round(snapReplacementCost, 2),
+                    Math.Round(tierGold, 2),
+                    tierWeight,
+                    Math.Round(contribution, 2));
+            }
+
+            var result = Math.Round(weightedGold, 2);
+            _logger.LogInformation("[PROGRESSIVE] Progressive baseline result: {Result}g/catch (WITH equipment progression)", result);
+            return result;
+        }
+
+        private static List<ProgressionTier> BuildProgressionTiers(int targetWeeks)
+        {
             var tiers = new List<ProgressionTier>
             {
                 new ProgressionTier { Name = "Naked", Weeks = 2, RarityBoost = 0.0, StarBoost = 0.0, WeightBoost = 0.0 },
-                new ProgressionTier { Name = "Entry", Weeks = 5, RarityBoost = 0.05, StarBoost = 0.10, WeightBoost = 0.10 },
-                new ProgressionTier { Name = "Mid", Weeks = 6, RarityBoost = 0.10, StarBoost = 0.20, WeightBoost = 0.20 },
-                new ProgressionTier { Name = "High", Weeks = 7, RarityBoost = 0.15, StarBoost = 0.30, WeightBoost = 0.30 },
-                new ProgressionTier { Name = "Top", Weeks = 6, RarityBoost = 0.25, StarBoost = 0.42, WeightBoost = 0.45 }
+                new ProgressionTier { Name = "Entry", Weeks = 5, RarityBoost = 0.05, StarBoost = 0.10, WeightBoost = 0.10, RodName = "Bamboo Rod", LineName = "Monofilament Line", HookName = "Standard Hook" },
+                new ProgressionTier { Name = "Mid", Weeks = 6, RarityBoost = 0.10, StarBoost = 0.20, WeightBoost = 0.20, RodName = "Fiberglass Rod", LineName = "Braided Line", HookName = "Circle Hook" },
+                new ProgressionTier { Name = "High", Weeks = 7, RarityBoost = 0.15, StarBoost = 0.30, WeightBoost = 0.30, RodName = "Carbon Fiber Rod", LineName = "Fluorocarbon Line", HookName = "Treble Hook" },
+                new ProgressionTier { Name = "Top", Weeks = 6, RarityBoost = 0.25, StarBoost = 0.42, WeightBoost = 0.45, RodName = "Legendary Rod", LineName = "Titanium Wire", HookName = "Diamond Hook" }
             };
 
             if (targetWeeks != 26)
@@ -467,24 +552,78 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 }
             }
 
+            return tiers;
+        }
+
+        private static double CalculateWeightedSnapReplacementCostPerAttempt(
+            List<ProgressionTier> tiers,
+            Dictionary<string, int> shopItemCosts,
+            double lineSnapChance,
+            double rodSnapChance)
+        {
             var totalWeeks = tiers.Sum(t => t.Weeks);
-            double weightedGold = 0.0;
-
-            _logger.LogInformation("[PROGRESSIVE] Tier breakdown:");
-            foreach (var tier in tiers)
+            if (totalWeeks <= 0)
             {
-                var tierGold = CalculateExpectedGoldWithBoosts(fishTypes, tier.RarityBoost, tier.StarBoost, tier.WeightBoost);
-                var tierWeight = tier.Weeks / (double)totalWeeks;
-                var contribution = tierGold * tierWeight;
-                weightedGold += contribution;
-
-                _logger.LogInformation("[PROGRESSIVE]   {Name}: {Weeks}wk, {Gold}g/catch × {Weight:P1} = {Contribution}g", 
-                    tier.Name, tier.Weeks, Math.Round(tierGold, 2), tierWeight, Math.Round(contribution, 2));
+                return 0.0;
             }
 
-            var result = Math.Round(weightedGold, 2);
-            _logger.LogInformation("[PROGRESSIVE] Progressive baseline result: {Result}g/catch (WITH equipment progression)", result);
-            return result;
+            double weighted = 0.0;
+            foreach (var tier in tiers)
+            {
+                var weight = tier.Weeks / (double)totalWeeks;
+                var tierCost = CalculateExpectedSnapReplacementCost(tier, shopItemCosts, lineSnapChance, rodSnapChance);
+                weighted += tierCost * weight;
+            }
+
+            return weighted;
+        }
+
+        private static double CalculateExpectedSnapReplacementCost(
+            ProgressionTier tier,
+            Dictionary<string, int> shopItemCosts,
+            double lineSnapChance,
+            double rodSnapChance)
+        {
+            if (string.IsNullOrWhiteSpace(tier.LineName) || string.IsNullOrWhiteSpace(tier.HookName))
+            {
+                return 0.0;
+            }
+
+            var lineCost = ResolveCost(tier.LineName, shopItemCosts, tier.Name, "line");
+            var hookCost = ResolveCost(tier.HookName, shopItemCosts, tier.Name, "hook");
+            var rodCost = string.IsNullOrWhiteSpace(tier.RodName)
+                ? 0
+                : ResolveCost(tier.RodName, shopItemCosts, tier.Name, "rod");
+
+            var lineFailureCost = lineCost + hookCost;
+            var rodFailureCost = rodCost + lineCost + hookCost;
+
+            return ((1.0 - rodSnapChance) * lineSnapChance * lineFailureCost) + (rodSnapChance * rodFailureCost);
+        }
+
+        private static int ResolveCost(string itemName, Dictionary<string, int> shopItemCosts, string tierName, string slot)
+        {
+            if (shopItemCosts.TryGetValue(itemName, out var liveCost) && liveCost > 0)
+            {
+                return liveCost;
+            }
+
+            return tierName switch
+            {
+                "Entry" when slot == "rod" => 150,
+                "Entry" when slot == "line" => 175,
+                "Entry" when slot == "hook" => 150,
+                "Mid" when slot == "rod" => 400,
+                "Mid" when slot == "line" => 450,
+                "Mid" when slot == "hook" => 400,
+                "High" when slot == "rod" => 1000,
+                "High" when slot == "line" => 1100,
+                "High" when slot == "hook" => 1000,
+                "Top" when slot == "rod" => 2500,
+                "Top" when slot == "line" => 2800,
+                "Top" when slot == "hook" => 2500,
+                _ => 0
+            };
         }
 
         private double CalculateExpectedGoldWithBoosts(
@@ -710,6 +849,9 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             public double RarityBoost { get; set; }
             public double StarBoost { get; set; }
             public double WeightBoost { get; set; }
+            public string? RodName { get; set; }
+            public string? LineName { get; set; }
+            public string? HookName { get; set; }
         }
 
         private static List<double> CalculateUserAverageCatchesPerSession(
@@ -770,6 +912,19 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 EndDate = endDate
             };
 
+            var settings = await _fishingService.GetSettings() ?? new FishingSettings();
+            var lineSnapChance = settings.LineSnapChance > 0 && settings.LineSnapChance <= 1
+                ? settings.LineSnapChance
+                : FishingSettings.DefaultLineSnapChance;
+            var rodSnapChance = settings.RodSnapChance > 0 && settings.RodSnapChance <= 1
+                ? settings.RodSnapChance
+                : FishingSettings.DefaultRodSnapChance;
+            var successfulAttemptChance = (1.0 - rodSnapChance) * (1.0 - lineSnapChance);
+
+            report.ConfiguredLineSnapChance = lineSnapChance;
+            report.ConfiguredRodSnapChance = rodSnapChance;
+            report.EstimatedSuccessfulAttemptRatePercent = Math.Round(successfulAttemptChance * 100.0, 2);
+
             // Build query for catches within date range
             var catchesQuery = context.FishCatches
                 .Include(c => c.FishType)
@@ -786,8 +941,31 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             report.TotalCatches = catches.Count;
             report.UniqueUsers = catches.Select(c => c.UserId).Distinct().Count();
 
+            report.EstimatedTotalAttempts = successfulAttemptChance > 0
+                ? (int)Math.Round(report.TotalCatches / successfulAttemptChance)
+                : report.TotalCatches;
+            report.EstimatedFailedAttempts = Math.Max(0, report.EstimatedTotalAttempts - report.TotalCatches);
+            report.EstimatedLineSnaps = (int)Math.Round(report.EstimatedTotalAttempts * (1.0 - rodSnapChance) * lineSnapChance);
+            report.EstimatedRodSnaps = (int)Math.Round(report.EstimatedTotalAttempts * rodSnapChance);
+
+            var shopItemCosts = await context.FishingShopItems
+                .AsNoTracking()
+                .ToDictionaryAsync(i => i.Name, i => i.Cost, StringComparer.OrdinalIgnoreCase);
+            var progressionTiers = BuildProgressionTiers(26);
+            var weightedSnapCostPerAttempt = CalculateWeightedSnapReplacementCostPerAttempt(
+                progressionTiers,
+                shopItemCosts,
+                lineSnapChance,
+                rodSnapChance);
+
+            report.EstimatedSnapReplacementCostPerAttempt = Math.Round(weightedSnapCostPerAttempt, 2);
+            report.EstimatedSnapReplacementCostTotal = Math.Round(weightedSnapCostPerAttempt * report.EstimatedTotalAttempts, 2);
+
             if (report.TotalCatches == 0)
             {
+                report.SnapAdjustedAverageGoldPerAttempt = Math.Round(0.0 - weightedSnapCostPerAttempt, 2);
+                report.SnapAdjustedMedianGoldPerAttempt = Math.Round(0.0 - weightedSnapCostPerAttempt, 2);
+                report.SnapAdjustedTotalNetGold = Math.Round(0.0 - report.EstimatedSnapReplacementCostTotal, 2);
                 report.Summary = "No catches found in the specified date range.";
                 return report;
             }
@@ -833,6 +1011,9 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 : goldValues[goldValues.Count / 2];
             report.MinGoldEarned = goldValues.Min();
             report.MaxGoldEarned = goldValues.Max();
+            report.SnapAdjustedAverageGoldPerAttempt = Math.Round((report.AverageGoldPerCatch * successfulAttemptChance) - weightedSnapCostPerAttempt, 2);
+            report.SnapAdjustedMedianGoldPerAttempt = Math.Round((report.MedianGoldPerCatch * successfulAttemptChance) - weightedSnapCostPerAttempt, 2);
+            report.SnapAdjustedTotalNetGold = Math.Round((report.TotalGoldEarned * successfulAttemptChance) - report.EstimatedSnapReplacementCostTotal, 2);
 
             // Per-user statistics
             var userGroups = catches.GroupBy(c => c.UserId)
@@ -876,7 +1057,6 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             }
 
             // Get boost mode settings
-            var settings = await _fishingService.GetSettings();
             report.BoostModeActive = settings?.BoostMode;
             report.BoostModeMultiplier = settings?.BoostModeRarityMultiplier;
 
@@ -964,6 +1144,10 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 boostModeMultiplier,
                 new List<UserFishingBoost>());
 
+            var effectiveGoldPerAttempt = report.SnapAdjustedAverageGoldPerAttempt > 0
+                ? report.SnapAdjustedAverageGoldPerAttempt
+                : report.AverageGoldPerCatch;
+
             foreach (var item in shopItems)
             {
                 var affordability = new ItemAffordability
@@ -986,8 +1170,8 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                     : 0;
 
                 // How many catches needed to afford
-                affordability.CatchesNeededToBuy = report.AverageGoldPerCatch > 0
-                    ? Math.Round(item.Cost / report.AverageGoldPerCatch, 1)
+                affordability.CatchesNeededToBuy = effectiveGoldPerAttempt > 0
+                    ? Math.Round(item.Cost / effectiveGoldPerAttempt, 1)
                     : 0;
 
                 // Sessions to afford based on REAL player engagement data (percentiles)
@@ -1078,6 +1262,18 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             if (report.RarityPercentages[FishRarity.Legendary] < 0.1 && report.TotalCatches > 1000)
                 recommendations.Add("⚠️ Legendary fish are extremely rare (<0.1%). Consider slightly increasing drop rates for better player experience.");
 
+            if (report.SnapAdjustedAverageGoldPerAttempt <= 0)
+                recommendations.Add("⚠️ Snap-adjusted net gold/attempt is non-positive. Lower snap rates or reduce rod/line/hook prices.");
+
+            if (report.EstimatedFailedAttempts > 0 && report.EstimatedTotalAttempts > 0)
+            {
+                var failPct = Math.Round((double)report.EstimatedFailedAttempts / report.EstimatedTotalAttempts * 100.0, 2);
+                if (failPct > 5.0)
+                {
+                    recommendations.Add($"⚠️ Estimated snap failure rate is {failPct:F2}%. Consider lowering line/rod snap chances.");
+                }
+            }
+
             // Gold economy check - items taking more than 20 sessions (10 weeks at 2 sessions/week)
             var expensiveItems = report.ItemAffordabilityAnalysis
                 .Where(i => !i.IsConsumable && i.SessionsToAffordActive > 20)
@@ -1122,7 +1318,8 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 $"Total gold earned: {report.TotalGoldEarned:N0} (avg {report.AverageGoldPerCatch:F1} per catch).",
                 $"Most common rarity: {report.RarityDistribution.OrderByDescending(kvp => kvp.Value).First().Key} ({report.RarityPercentages[report.RarityDistribution.OrderByDescending(kvp => kvp.Value).First().Key]:F1}%).",
                 $"Most caught fish: {report.MostCaughtFish ?? "N/A"}.",
-                $"Player engagement (real data): Casual={report.CasualCatchesPerSession:F1}, Active={report.ActiveCatchesPerSession:F1}, Hardcore={report.HardcoreCatchesPerSession:F1} catches/session."
+                $"Player engagement (real data): Casual={report.CasualCatchesPerSession:F1}, Active={report.ActiveCatchesPerSession:F1}, Hardcore={report.HardcoreCatchesPerSession:F1} catches/session.",
+                $"Snap impact estimate: {report.EstimatedFailedAttempts:N0} failed attempts ({Math.Round((double)report.EstimatedFailedAttempts / Math.Max(1, report.EstimatedTotalAttempts) * 100.0, 2):F2}%), net {report.SnapAdjustedAverageGoldPerAttempt:F2}g/attempt after replacement costs."
             };
 
             if (report.BoostModeActive == true)
@@ -1278,6 +1475,94 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 recommendations.Count);
 
             return recommendations;
+        }
+
+        private static double ApplyLineSnapLosses(List<UserFishingBoost> boosts)
+        {
+            var replacementCost = 0.0;
+
+            // Charge replacement for line/hook every time they snap,
+            // but keep them in the simulated loadout so future snaps can still incur cost.
+            foreach (var item in boosts.Where(b => b.ShopItem?.EquipmentSlot == EquipmentSlot.Line || b.ShopItem?.EquipmentSlot == EquipmentSlot.Hook))
+            {
+                replacementCost += item.ShopItem?.Cost ?? 0;
+            }
+
+            var baitLureItems = boosts
+                .Where(b => b.ShopItem?.EquipmentSlot == EquipmentSlot.Bait || b.ShopItem?.EquipmentSlot == EquipmentSlot.Lure)
+                .ToList();
+
+            foreach (var item in baitLureItems)
+            {
+                if (item.RemainingUses == -1)
+                {
+                    // Unlimited bait/lure are lost and replaced on snap.
+                    replacementCost += item.ShopItem?.Cost ?? 0;
+                    continue;
+                }
+
+                if (item.RemainingUses > 0)
+                {
+                    item.RemainingUses--;
+
+                    var maxUses = item.ShopItem?.MaxUses ?? 1;
+                    var perUseCost = maxUses > 0
+                        ? (item.ShopItem?.Cost ?? 0) / (double)maxUses
+                        : item.ShopItem?.Cost ?? 0;
+
+                    replacementCost += perUseCost;
+                }
+
+                if (item.RemainingUses <= 0)
+                {
+                    boosts.Remove(item);
+                }
+            }
+
+            return replacementCost;
+        }
+
+        private static double ApplyRodSnapLosses(List<UserFishingBoost> boosts)
+        {
+            var replacementCost = 0.0;
+
+            // Charge replacement for rod every time it snaps,
+            // but keep it in simulated loadout for future attempts.
+            foreach (var rod in boosts.Where(b => b.ShopItem?.EquipmentSlot == EquipmentSlot.Rod))
+            {
+                replacementCost += rod.ShopItem?.Cost ?? 0;
+            }
+
+            replacementCost += ApplyLineSnapLosses(boosts);
+            return replacementCost;
+        }
+
+        private static void ConsumeUsesAfterCatch(List<UserFishingBoost> boosts)
+        {
+            var removable = new List<UserFishingBoost>();
+
+            foreach (var boost in boosts)
+            {
+                if (boost.RemainingUses == -1)
+                {
+                    continue;
+                }
+
+                if (boost.RemainingUses > 0)
+                {
+                    boost.RemainingUses--;
+                }
+
+                if (boost.RemainingUses <= 0)
+                {
+                    removable.Add(boost);
+                }
+            }
+
+            foreach (var expired in removable)
+            {
+                boosts.Remove(expired);
+            }
         }
     }
 }

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingAnalyticsService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingAnalyticsService.cs
@@ -155,7 +155,9 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             }
 
             // Calculate statistics
-            result.AverageWeight = Math.Round(totalWeight / iterations, 2);
+            result.AverageWeight = result.SuccessfulCatches > 0
+                ? Math.Round(totalWeight / result.SuccessfulCatches, 2)
+                : 0;
             result.AverageGold = Math.Round((double)totalGold / iterations, 2);
             result.TotalGold = totalGold;
             result.MinWeight = result.SuccessfulCatches > 0 ? Math.Round(minWeight, 2) : 0;
@@ -532,7 +534,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             }
 
             var result = Math.Round(weightedGold, 2);
-            _logger.LogInformation("[PROGRESSIVE] Progressive baseline result: {Result}g/catch (WITH equipment progression)", result);
+            _logger.LogInformation("[PROGRESSIVE] Progressive baseline result: {Result}g/attempt (WITH equipment progression)", result);
             return result;
         }
 
@@ -1019,7 +1021,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             report.MaxGoldEarned = goldValues.Max();
             report.SnapAdjustedAverageGoldPerAttempt = Math.Round((report.AverageGoldPerCatch * successfulAttemptChance) - weightedSnapCostPerAttempt, 2);
             report.SnapAdjustedMedianGoldPerAttempt = Math.Round((report.MedianGoldPerCatch * successfulAttemptChance) - weightedSnapCostPerAttempt, 2);
-            report.SnapAdjustedTotalNetGold = Math.Round((report.TotalGoldEarned * successfulAttemptChance) - report.EstimatedSnapReplacementCostTotal, 2);
+            report.SnapAdjustedTotalNetGold = Math.Round(report.TotalGoldEarned - report.EstimatedSnapReplacementCostTotal, 2);
 
             // Per-user statistics
             var userGroups = catches.GroupBy(c => c.UserId)
@@ -1150,9 +1152,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 boostModeMultiplier,
                 new List<UserFishingBoost>());
 
-            var effectiveGoldPerAttempt = report.SnapAdjustedAverageGoldPerAttempt > 0
-                ? report.SnapAdjustedAverageGoldPerAttempt
-                : report.AverageGoldPerCatch;
+            var effectiveGoldPerAttempt = Math.Max(0, report.SnapAdjustedAverageGoldPerAttempt);
 
             foreach (var item in shopItems)
             {

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingGameplayService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingGameplayService.cs
@@ -28,7 +28,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             _inventoryService = inventoryService;
         }
 
-        public async Task<FishCatch> PerformFishingAttempt(string userId, string username)
+        public async Task<FishingAttemptResult> PerformFishingAttempt(string userId, string username)
         {
             // Only get enabled fish types
             var allFishTypes = await _fishingService.GetAllFishTypes();
@@ -42,6 +42,87 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             var settings = await _fishingService.GetSettings();
             // Only get equipped items, not all boosts
             var userBoosts = await _inventoryService.GetUserEquippedItems(userId);
+
+            var lineSnapChance = settings?.LineSnapChance > 0
+                ? settings.LineSnapChance
+                : FishingSettings.DefaultLineSnapChance;
+            var rodSnapChance = settings?.RodSnapChance > 0
+                ? settings.RodSnapChance
+                : FishingSettings.DefaultRodSnapChance;
+
+            if (Random.Shared.NextDouble() < rodSnapChance)
+            {
+                await _inventoryService.ConsumeItemsOnRodSnap(userId);
+
+                try
+                {
+                    await _hubContext.Clients.All.SendAsync("ReceiveFishCatch", new
+                    {
+                        Id = 0,
+                        UserId = userId,
+                        Username = username,
+                        FishTypeId = 0,
+                        FishName = "ROD SNAPPED",
+                        FishRarity = "Accident",
+                        FishImageFileName = "",
+                        Stars = 0,
+                        Weight = 0.0,
+                        GoldEarned = 0,
+                        CaughtAt = DateTime.UtcNow,
+                        IsLineSnapped = true,
+                        IsRodSnapped = true
+                    });
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to broadcast snapped rod event via SignalR");
+                }
+
+                return new FishingAttemptResult
+                {
+                    Outcome = FishingAttemptOutcome.RodSnapped,
+                    LostEquipmentSlots = new List<EquipmentSlot>
+                    {
+                        EquipmentSlot.Rod,
+                        EquipmentSlot.Line,
+                        EquipmentSlot.Hook
+                    }
+                };
+            }
+
+            if (Random.Shared.NextDouble() < lineSnapChance)
+            {
+                await _inventoryService.ConsumeItemsOnLineSnap(userId);
+
+                try
+                {
+                    await _hubContext.Clients.All.SendAsync("ReceiveFishCatch", new
+                    {
+                        Id = 0,
+                        UserId = userId,
+                        Username = username,
+                        FishTypeId = 0,
+                        FishName = "LINE SNAPPED",
+                        FishRarity = "Accident",
+                        FishImageFileName = "",
+                        Stars = 0,
+                        Weight = 0.0,
+                        GoldEarned = 0,
+                        CaughtAt = DateTime.UtcNow,
+                        IsLineSnapped = true
+                    });
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Failed to broadcast snapped line event via SignalR");
+                }
+
+                return new FishingAttemptResult
+                {
+                    Outcome = FishingAttemptOutcome.LineSnapped,
+                    LostEquipmentSlots = new List<EquipmentSlot> { EquipmentSlot.Line, EquipmentSlot.Hook }
+                };
+            }
 
             var fishType = FishingCalculations.SelectRandomFish(fishTypes, settings, userBoosts);
             var stars = FishingCalculations.CalculateStars(fishType, userBoosts);
@@ -99,7 +180,11 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 _logger.LogError(ex, "Failed to broadcast fish catch via SignalR");
             }
 
-            return fishCatch;
+            return new FishingAttemptResult
+            {
+                Outcome = FishingAttemptOutcome.CaughtFish,
+                FishCatch = fishCatch
+            };
         }
     }
 }

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingGameplayService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingGameplayService.cs
@@ -43,10 +43,18 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             // Only get equipped items, not all boosts
             var userBoosts = await _inventoryService.GetUserEquippedItems(userId);
 
-            var lineSnapChance = settings?.LineSnapChance > 0
+            var lineSnapChance = settings != null &&
+                !double.IsNaN(settings.LineSnapChance) &&
+                !double.IsInfinity(settings.LineSnapChance) &&
+                settings.LineSnapChance >= 0 &&
+                settings.LineSnapChance <= 1
                 ? settings.LineSnapChance
                 : FishingSettings.DefaultLineSnapChance;
-            var rodSnapChance = settings?.RodSnapChance > 0
+            var rodSnapChance = settings != null &&
+                !double.IsNaN(settings.RodSnapChance) &&
+                !double.IsInfinity(settings.RodSnapChance) &&
+                settings.RodSnapChance >= 0 &&
+                settings.RodSnapChance <= 1
                 ? settings.RodSnapChance
                 : FishingSettings.DefaultRodSnapChance;
 

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingInventoryService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingInventoryService.cs
@@ -234,5 +234,83 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
 
             await context.SaveChangesAsync();
         }
+
+        public async Task ConsumeItemsOnLineSnap(string userId)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            await ApplySnapLosses(context, userId, includeRodLoss: false);
+            await context.SaveChangesAsync();
+        }
+
+        public async Task ConsumeItemsOnRodSnap(string userId)
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            await ApplySnapLosses(context, userId, includeRodLoss: true);
+            await context.SaveChangesAsync();
+        }
+
+        private static async Task ApplySnapLosses(ApplicationDbContext context, string userId, bool includeRodLoss)
+        {
+            var equippedItems = await context.UserFishingBoosts
+                .Include(b => b.ShopItem)
+                .Where(b => b.UserId == userId && b.IsEquipped)
+                .ToListAsync();
+
+            if (includeRodLoss)
+            {
+                foreach (var rodItem in equippedItems.Where(i => i.ShopItem?.EquipmentSlot == EquipmentSlot.Rod))
+                {
+                    context.UserFishingBoosts.Remove(rodItem);
+                }
+            }
+
+            foreach (var item in equippedItems)
+            {
+                var slot = item.ShopItem?.EquipmentSlot;
+
+                if (includeRodLoss && slot == EquipmentSlot.Rod)
+                {
+                    continue;
+                }
+
+                // Line/hook are always lost on a snapped line.
+                if (slot == EquipmentSlot.Line || slot == EquipmentSlot.Hook)
+                {
+                    context.UserFishingBoosts.Remove(item);
+                    continue;
+                }
+
+                if (slot != EquipmentSlot.Bait && slot != EquipmentSlot.Lure)
+                {
+                    continue;
+                }
+
+                if (item.RemainingUses == -1)
+                {
+                    // Unlimited bait/lure are fully lost on snap.
+                    context.UserFishingBoosts.Remove(item);
+                    continue;
+                }
+
+                if (item.RemainingUses > 0)
+                {
+                    item.RemainingUses--;
+                }
+
+                item.LastUsedAt = DateTime.UtcNow;
+
+                if (item.ShopItem?.IsConsumable == true && item.RemainingUses <= 0)
+                {
+                    item.IsEquipped = false;
+                    context.UserFishingBoosts.Remove(item);
+                }
+                else if (item.RemainingUses <= 0)
+                {
+                    item.IsEquipped = false;
+                }
+            }
+        }
     }
 }

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingShopItemGenerator.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingShopItemGenerator.cs
@@ -36,9 +36,6 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             AddBaits(itemsToAdd, ItemExists);
             AddLures(itemsToAdd, ItemExists);
 
-            // Add fish-specific items
-            await AddFishSpecificItems(context, itemsToAdd, ItemExists);
-
             var changedCount = 0;
 
             if (updateExisting && itemsToAdd.Any())
@@ -220,97 +217,5 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 items.Add(new FishingShopItem { Name = "Swimbait", Description = "Realistic swimming lure (+45% rarity, 5 uses)", Cost = 400, BoostType = FishingBoostType.GeneralRarityBoost, BoostAmount = 0.45, EquipmentSlot = EquipmentSlot.Lure, IsConsumable = true, MaxUses = 5, Enabled = true });
         }
 
-        private async Task AddFishSpecificItems(ApplicationDbContext context, List<FishingShopItem> items, Func<string, bool> itemExists)
-        {
-            var allFish = await context.FishTypes.Where(f => f.Enabled).ToListAsync();
-            var targetFish = allFish.Where(f => f.Rarity >= FishRarity.Rare).ToList();
-
-            foreach (var fish in targetFish)
-            {
-                // Fish-Specific Bait
-                var baitName = $"{fish.Name} Bait";
-                if (!itemExists(baitName))
-                {
-                    var baitCost = fish.Rarity switch
-                    {
-                        FishRarity.Legendary => 800,
-                        FishRarity.Epic => 450,
-                        FishRarity.Rare => 250,
-                        _ => 150
-                    };
-
-                    var baitBoost = fish.Rarity switch
-                    {
-                        FishRarity.Legendary => 3.5,   // 350% boost
-                        FishRarity.Epic => 2.5,        // 250% boost
-                        FishRarity.Rare => 1.8,        // 180% boost
-                        _ => 1.0
-                    };
-
-                    var baitUses = fish.Rarity switch
-                    {
-                        FishRarity.Legendary => 8,
-                        FishRarity.Epic => 10,
-                        _ => 12
-                    };
-
-                    items.Add(new FishingShopItem
-                    {
-                        Name = baitName,
-                        Description = $"Specialized bait for {fish.Name} ({baitUses} uses)",
-                        Cost = baitCost,
-                        BoostType = FishingBoostType.SpecificFishBoost,
-                        BoostAmount = baitBoost,
-                        TargetFishTypeId = fish.Id,
-                        IsConsumable = true,
-                        MaxUses = baitUses,
-                        Enabled = true,
-                        EquipmentSlot = EquipmentSlot.Bait
-                    });
-                }
-
-                // Fish-Specific Lure
-                var lureName = $"{fish.Name} Lure";
-                if (!itemExists(lureName))
-                {
-                    var lureCost = fish.Rarity switch
-                    {
-                        FishRarity.Legendary => 1000,
-                        FishRarity.Epic => 600,
-                        FishRarity.Rare => 350,
-                        _ => 200
-                    };
-
-                    var lureBoost = fish.Rarity switch
-                    {
-                        FishRarity.Legendary => 4.5,   // 450% boost  
-                        FishRarity.Epic => 3.0,        // 300% boost
-                        FishRarity.Rare => 2.2,        // 220% boost
-                        _ => 1.2
-                    };
-
-                    var lureUses = fish.Rarity switch
-                    {
-                        FishRarity.Legendary => 10,
-                        FishRarity.Epic => 12,
-                        _ => 15
-                    };
-
-                    items.Add(new FishingShopItem
-                    {
-                        Name = lureName,
-                        Description = $"Premium lure designed for {fish.Name} ({lureUses} uses)",
-                        Cost = lureCost,
-                        BoostType = FishingBoostType.SpecificFishBoost,
-                        BoostAmount = lureBoost,
-                        TargetFishTypeId = fish.Id,
-                        IsConsumable = true,
-                        MaxUses = lureUses,
-                        Enabled = true,
-                        EquipmentSlot = EquipmentSlot.Lure
-                    });
-                }
-            }
-        }
     }
 }

--- a/DotNetTwitchBot/Bot/Commands/Fishing/IFishingAnalyticsService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/IFishingAnalyticsService.cs
@@ -5,7 +5,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
 {
     public interface IFishingAnalyticsService
     {
-        Task<FishingSimulationResult> SimulateFishing(int iterations, bool useBoostMode, double boostModeMultiplier, List<int> shopItemIds);
+        Task<FishingSimulationResult> SimulateFishing(int iterations, List<int> shopItemIds);
         Task<Dictionary<int, FishProbability>> CalculateCatchProbabilities(List<int> shopItemIds);
         Task<Dictionary<int, FishProbability>> CalculateCatchProbabilities(bool useBoostMode, double boostModeMultiplier, List<int> shopItemIds);
         Task<RarityProbability> CalculateRarityProbabilities(bool useBoostMode, double boostModeMultiplier, List<int> shopItemIds);

--- a/DotNetTwitchBot/Bot/Commands/Fishing/IFishingGameplayService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/IFishingGameplayService.cs
@@ -4,6 +4,6 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
 {
     public interface IFishingGameplayService
     {
-        Task<FishCatch> PerformFishingAttempt(string userId, string username);
+        Task<FishingAttemptResult> PerformFishingAttempt(string userId, string username);
     }
 }

--- a/DotNetTwitchBot/Bot/Commands/Fishing/IFishingInventoryService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/IFishingInventoryService.cs
@@ -13,5 +13,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
         Task EquipItem(string userId, int userBoostId);
         Task UnequipItem(string userId, int userBoostId);
         Task ConsumeItemUse(string userId, int userBoostId);
+        Task ConsumeItemsOnLineSnap(string userId);
+        Task ConsumeItemsOnRodSnap(string userId);
     }
 }

--- a/DotNetTwitchBot/Bot/Models/Fishing/FishingAttemptResult.cs
+++ b/DotNetTwitchBot/Bot/Models/Fishing/FishingAttemptResult.cs
@@ -1,0 +1,18 @@
+namespace DotNetTwitchBot.Bot.Models.Fishing
+{
+    public class FishingAttemptResult
+    {
+        public FishingAttemptOutcome Outcome { get; set; } = FishingAttemptOutcome.CaughtFish;
+        public FishCatch? FishCatch { get; set; }
+        public List<EquipmentSlot> LostEquipmentSlots { get; set; } = new();
+
+        public bool IsSuccessfulCatch => Outcome == FishingAttemptOutcome.CaughtFish && FishCatch != null;
+    }
+
+    public enum FishingAttemptOutcome
+    {
+        CaughtFish,
+        LineSnapped,
+        RodSnapped
+    }
+}

--- a/DotNetTwitchBot/Bot/Models/Fishing/FishingBalanceReport.cs
+++ b/DotNetTwitchBot/Bot/Models/Fishing/FishingBalanceReport.cs
@@ -25,6 +25,20 @@ namespace DotNetTwitchBot.Bot.Models.Fishing
         public double MedianGoldPerCatch { get; set; }
         public int MinGoldEarned { get; set; }
         public int MaxGoldEarned { get; set; }
+
+        // Snap-adjusted economics (estimates derived from configured snap rates)
+        public double ConfiguredLineSnapChance { get; set; }
+        public double ConfiguredRodSnapChance { get; set; }
+        public double EstimatedSuccessfulAttemptRatePercent { get; set; }
+        public int EstimatedTotalAttempts { get; set; }
+        public int EstimatedFailedAttempts { get; set; }
+        public int EstimatedLineSnaps { get; set; }
+        public int EstimatedRodSnaps { get; set; }
+        public double EstimatedSnapReplacementCostPerAttempt { get; set; }
+        public double EstimatedSnapReplacementCostTotal { get; set; }
+        public double SnapAdjustedAverageGoldPerAttempt { get; set; }
+        public double SnapAdjustedMedianGoldPerAttempt { get; set; }
+        public double SnapAdjustedTotalNetGold { get; set; }
         
         // Per-User Statistics
         public double AverageCatchesPerUser { get; set; }

--- a/DotNetTwitchBot/Bot/Models/Fishing/FishingSettings.cs
+++ b/DotNetTwitchBot/Bot/Models/Fishing/FishingSettings.cs
@@ -4,12 +4,17 @@ namespace DotNetTwitchBot.Bot.Models.Fishing
 {
     public class FishingSettings
     {
+        public const double DefaultLineSnapChance = 0.02;
+        public const double DefaultRodSnapChance = 0.0005;
+
         [Key]
         public int Id { get; set; }
         public bool Enabled { get; set; } = true;
         public int DisplayDurationMs { get; set; } = 5000;
         public bool BoostMode { get; set; } = false;
         public double BoostModeRarityMultiplier { get; set; } = 2.0;
+        public double LineSnapChance { get; set; } = DefaultLineSnapChance;
+        public double RodSnapChance { get; set; } = DefaultRodSnapChance;
 
         // Rarity thresholds based on BaseGold values
         public int RarityUncommonThreshold { get; set; } = 35;

--- a/DotNetTwitchBot/Bot/Models/Fishing/FishingSimulationResult.cs
+++ b/DotNetTwitchBot/Bot/Models/Fishing/FishingSimulationResult.cs
@@ -13,6 +13,16 @@ namespace DotNetTwitchBot.Bot.Models.Fishing
         public double MaxWeight { get; set; }
         public string? HeaviestFish { get; set; }
         public string? MostCommonFish { get; set; }
+        public int SuccessfulCatches { get; set; }
+        public int FailedAttempts { get; set; }
+        public int LineSnapCount { get; set; }
+        public int RodSnapCount { get; set; }
+        public double SnapFailureRatePercent { get; set; }
+        public double AppliedLineSnapChance { get; set; }
+        public double AppliedRodSnapChance { get; set; }
+        public double SnapReplacementCostTotal { get; set; }
+        public double NetGoldAfterSnapCosts { get; set; }
+        public double NetAverageGoldPerAttempt { get; set; }
         public bool BoostModeUsed { get; set; }
         public double BoostModeMultiplier { get; set; }
         public List<string> ItemsUsed { get; set; } = new();

--- a/DotNetTwitchBot/Migrations/20260504162418_AddFishingSnapChances.Designer.cs
+++ b/DotNetTwitchBot/Migrations/20260504162418_AddFishingSnapChances.Designer.cs
@@ -4,6 +4,7 @@ using DotNetTwitchBot.Bot.Core.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DotNetTwitchBot.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260504162418_AddFishingSnapChances")]
+    partial class AddFishingSnapChances
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DotNetTwitchBot/Migrations/20260504162418_AddFishingSnapChances.cs
+++ b/DotNetTwitchBot/Migrations/20260504162418_AddFishingSnapChances.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DotNetTwitchBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFishingSnapChances : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "LineSnapChance",
+                table: "FishingSettings",
+                type: "double",
+                nullable: false,
+                defaultValue: 0.02);
+
+            migrationBuilder.AddColumn<double>(
+                name: "RodSnapChance",
+                table: "FishingSettings",
+                type: "double",
+                nullable: false,
+                defaultValue: 0.005);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "LineSnapChance",
+                table: "FishingSettings");
+
+            migrationBuilder.DropColumn(
+                name: "RodSnapChance",
+                table: "FishingSettings");
+        }
+    }
+}

--- a/DotNetTwitchBot/Pages/Fishing/FishingAdmin.razor
+++ b/DotNetTwitchBot/Pages/Fishing/FishingAdmin.razor
@@ -608,7 +608,7 @@
                                                     <MudPaper Elevation="2" Class="pa-3">
                                                         <MudStack Spacing="1" AlignItems="AlignItems.Center">
                                                             <MudIcon Icon="@Icons.Material.Filled.Scale" Color="Color.Info" Size="Size.Large" />
-                                                            <MudText Typo="Typo.caption">Avg Weight</MudText>
+                                                            <MudText Typo="Typo.caption">Avg Weight (Catch)</MudText>
                                                             <MudText Typo="Typo.h6">@simulationResult.AverageWeight kg</MudText>
                                                         </MudStack>
                                                     </MudPaper>

--- a/DotNetTwitchBot/Pages/Fishing/FishingAdmin.razor
+++ b/DotNetTwitchBot/Pages/Fishing/FishingAdmin.razor
@@ -252,6 +252,34 @@
                                  Adornment="Adornment.End"
                                  AdornmentText="x" />
 
+                <MudDivider />
+                <MudStack Spacing="1">
+                    <MudText Typo="Typo.subtitle2">Snap Chances</MudText>
+                    <MudText Typo="Typo.caption" Color="Color.Secondary">Set per-attempt probabilities. Values use decimal format (0.02 = 2%).</MudText>
+                </MudStack>
+                <MudGrid>
+                    <MudItem xs="12" sm="6">
+                        <MudNumericField @bind-Value="settings.LineSnapChance"
+                                         Label="Line Snap Chance"
+                                         HelperText="Default: 0.02 (2%)"
+                                         Min="0.0"
+                                         Max="1.0"
+                                         Step="0.001"
+                                         Adornment="Adornment.End"
+                                         AdornmentText="prob" />
+                    </MudItem>
+                    <MudItem xs="12" sm="6">
+                        <MudNumericField @bind-Value="settings.RodSnapChance"
+                                         Label="Rod Snap Chance"
+                                         HelperText="Default: 0.0005 (0.05%)"
+                                         Min="0.0"
+                                         Max="1.0"
+                                         Step="0.0001"
+                                         Adornment="Adornment.End"
+                                         AdornmentText="prob" />
+                    </MudItem>
+                </MudGrid>
+
                 <MudDivider Class="my-4" />
 
                 <MudStack Spacing="2">
@@ -375,24 +403,11 @@
                                                  Adornment="Adornment.Start"
                                                  AdornmentIcon="@Icons.Material.Filled.Replay" />
 
-                                <MudStack Spacing="2">
-                                    <MudSwitch @bind-Value="simUseBoostMode" 
-                                               Label="Use Boost Mode" 
-                                               Color="Color.Warning"
-                                               ThumbIcon="@(simUseBoostMode ? Icons.Material.Filled.TrendingUp : Icons.Material.Filled.TrendingFlat)" />
-
-                                    @if (simUseBoostMode)
-                                    {
-                                        <MudNumericField @bind-Value="simBoostMultiplier" 
-                                                         Label="Boost Mode Multiplier" 
-                                                         Min="1.0" 
-                                                         Max="10.0" 
-                                                         Step="0.1"
-                                                         Variant="Variant.Outlined"
-                                                         Adornment="Adornment.End"
-                                                         AdornmentText="x" />
-                                    }
-                                </MudStack>
+                                <MudAlert Severity="Severity.Info" Dense="true">
+                                    <MudText Typo="Typo.body2">
+                                        Simulator uses your current saved fishing settings (boost mode, boost multiplier, line snap chance, rod snap chance).
+                                    </MudText>
+                                </MudAlert>
 
                                 <MudStack Spacing="2">
                                     <MudText Typo="Typo.subtitle2">Equipped Items (Optional)</MudText>
@@ -440,7 +455,16 @@
 
                                     <MudAlert Severity="Severity.Success" Icon="@Icons.Material.Filled.CheckCircle">
                                         <MudText Typo="Typo.body1"><strong>Simulation Complete!</strong></MudText>
-                                        <MudText Typo="Typo.body2">@simulationResult.TotalIterations catches simulated</MudText>
+                                        <MudText Typo="Typo.body2">@simulationResult.TotalIterations attempts simulated (@simulationResult.SuccessfulCatches catches, @simulationResult.FailedAttempts failed)</MudText>
+                                    </MudAlert>
+
+                                    <MudAlert Severity="Severity.Info" Dense="true" Icon="@Icons.Material.Filled.CrisisAlert">
+                                        <MudText Typo="Typo.body2">
+                                            Snap results: @simulationResult.LineSnapCount line snaps, @simulationResult.RodSnapCount rod snaps (@simulationResult.SnapFailureRatePercent% failure rate)
+                                        </MudText>
+                                        <MudText Typo="Typo.caption">
+                                            Applied chances: line @((simulationResult.AppliedLineSnapChance * 100).ToString("F2"))%, rod @((simulationResult.AppliedRodSnapChance * 100).ToString("F2"))%
+                                        </MudText>
                                     </MudAlert>
 
                                     <MudExpansionPanels>
@@ -457,7 +481,8 @@
                                                 <tbody>
                                                     @foreach (var kvp in simulationResult.RarityCounts.OrderBy(k => (int)k.Key))
                                                     {
-                                                        var percentage = Math.Round((double)kvp.Value / simulationResult.TotalIterations * 100, 2);
+                                                        var denominator = Math.Max(1, simulationResult.SuccessfulCatches);
+                                                        var percentage = Math.Round((double)kvp.Value / denominator * 100, 2);
                                                         <tr>
                                                             <td>
                                                                 <MudChip T="string" Color="GetRarityColor(kvp.Key)" Size="Size.Small">@kvp.Key</MudChip>
@@ -486,7 +511,8 @@
                                                 <tbody>
                                                     @foreach (var kvp in simulationResult.StarCounts.OrderByDescending(k => k.Key))
                                                     {
-                                                        var percentage = Math.Round((double)kvp.Value / simulationResult.TotalIterations * 100, 2);
+                                                        var denominator = Math.Max(1, simulationResult.SuccessfulCatches);
+                                                        var percentage = Math.Round((double)kvp.Value / denominator * 100, 2);
                                                         <tr>
                                                             <td>
                                                                 <MudStack Row="true" AlignItems="AlignItems.Center">
@@ -519,7 +545,8 @@
                                                 <tbody>
                                                     @foreach (var kvp in simulationResult.FishCounts.OrderByDescending(k => k.Value).Take(10))
                                                     {
-                                                        var percentage = Math.Round((double)kvp.Value / simulationResult.TotalIterations * 100, 2);
+                                                        var denominator = Math.Max(1, simulationResult.SuccessfulCatches);
+                                                        var percentage = Math.Round((double)kvp.Value / denominator * 100, 2);
                                                         <tr>
                                                             <td><strong>@kvp.Key</strong></td>
                                                             <td>@kvp.Value</td>
@@ -532,16 +559,52 @@
 
                                         <MudExpansionPanel Text="Statistics Summary">
                                             <MudGrid>
-                                                <MudItem xs="6" sm="4">
+                                                <MudItem xs="12" sm="4" md="4">
                                                     <MudPaper Elevation="2" Class="pa-3">
                                                         <MudStack Spacing="1" AlignItems="AlignItems.Center">
-                                                            <MudIcon Icon="@Icons.Material.Filled.AttachMoney" Color="Color.Warning" Size="Size.Large" />
-                                                            <MudText Typo="Typo.caption">Avg Gold</MudText>
-                                                            <MudText Typo="Typo.h6">@simulationResult.AverageGold</MudText>
+                                                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Success" Size="Size.Large" />
+                                                            <MudText Typo="Typo.caption">Total Gold (Gross)</MudText>
+                                                            <MudText Typo="Typo.h6">@simulationResult.TotalGold</MudText>
                                                         </MudStack>
                                                     </MudPaper>
                                                 </MudItem>
-                                                <MudItem xs="6" sm="4">
+                                                <MudItem xs="12" sm="4" md="4">
+                                                    <MudPaper Elevation="2" Class="pa-3">
+                                                        <MudStack Spacing="1" AlignItems="AlignItems.Center">
+                                                            <MudIcon Icon="@Icons.Material.Filled.PriceCheck" Color="Color.Warning" Size="Size.Large" />
+                                                            <MudText Typo="Typo.caption">Snap Cost</MudText>
+                                                            <MudText Typo="Typo.h6">@simulationResult.SnapReplacementCostTotal.ToString("F2") g</MudText>
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                </MudItem>
+                                                <MudItem xs="12" sm="4" md="4">
+                                                    <MudPaper Elevation="2" Class="pa-3">
+                                                        <MudStack Spacing="1" AlignItems="AlignItems.Center">
+                                                            <MudIcon Icon="@Icons.Material.Filled.Savings" Color="Color.Success" Size="Size.Large" />
+                                                            <MudText Typo="Typo.caption">Total Gold (Net)</MudText>
+                                                            <MudText Typo="Typo.h6">@simulationResult.NetGoldAfterSnapCosts.ToString("F2")</MudText>
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                </MudItem>
+                                                <MudItem xs="6" sm="4" md="4">
+                                                    <MudPaper Elevation="2" Class="pa-3">
+                                                        <MudStack Spacing="1" AlignItems="AlignItems.Center">
+                                                            <MudIcon Icon="@Icons.Material.Filled.AttachMoney" Color="Color.Warning" Size="Size.Large" />
+                                                            <MudText Typo="Typo.caption">Avg Gold (Gross)</MudText>
+                                                            <MudText Typo="Typo.h6">@simulationResult.AverageGold.ToString("F2")</MudText>
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                </MudItem>
+                                                <MudItem xs="6" sm="4" md="4">
+                                                    <MudPaper Elevation="2" Class="pa-3">
+                                                        <MudStack Spacing="1" AlignItems="AlignItems.Center">
+                                                            <MudIcon Icon="@Icons.Material.Filled.AccountBalanceWallet" Color="Color.Success" Size="Size.Large" />
+                                                            <MudText Typo="Typo.caption">Avg Gold (Net)</MudText>
+                                                            <MudText Typo="Typo.h6">@simulationResult.NetAverageGoldPerAttempt.ToString("F2")</MudText>
+                                                        </MudStack>
+                                                    </MudPaper>
+                                                </MudItem>
+                                                <MudItem xs="6" sm="4" md="4">
                                                     <MudPaper Elevation="2" Class="pa-3">
                                                         <MudStack Spacing="1" AlignItems="AlignItems.Center">
                                                             <MudIcon Icon="@Icons.Material.Filled.Scale" Color="Color.Info" Size="Size.Large" />
@@ -550,16 +613,7 @@
                                                         </MudStack>
                                                     </MudPaper>
                                                 </MudItem>
-                                                <MudItem xs="6" sm="4">
-                                                    <MudPaper Elevation="2" Class="pa-3">
-                                                        <MudStack Spacing="1" AlignItems="AlignItems.Center">
-                                                            <MudIcon Icon="@Icons.Material.Filled.EmojiEvents" Color="Color.Success" Size="Size.Large" />
-                                                            <MudText Typo="Typo.caption">Total Gold</MudText>
-                                                            <MudText Typo="Typo.h6">@simulationResult.TotalGold</MudText>
-                                                        </MudStack>
-                                                    </MudPaper>
-                                                </MudItem>
-                                                <MudItem xs="6" sm="4">
+                                                <MudItem xs="6" sm="4" md="4">
                                                     <MudPaper Elevation="2" Class="pa-3">
                                                         <MudStack Spacing="1" AlignItems="AlignItems.Center">
                                                             <MudIcon Icon="@Icons.Material.Filled.TrendingDown" Color="Color.Default" Size="Size.Large" />
@@ -568,7 +622,7 @@
                                                         </MudStack>
                                                     </MudPaper>
                                                 </MudItem>
-                                                <MudItem xs="6" sm="4">
+                                                <MudItem xs="6" sm="4" md="4">
                                                     <MudPaper Elevation="2" Class="pa-3">
                                                         <MudStack Spacing="1" AlignItems="AlignItems.Center">
                                                             <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Color="Color.Error" Size="Size.Large" />
@@ -577,7 +631,7 @@
                                                         </MudStack>
                                                     </MudPaper>
                                                 </MudItem>
-                                                <MudItem xs="12" sm="4">
+                                                <MudItem xs="12" sm="4" md="4">
                                                     <MudPaper Elevation="2" Class="pa-3">
                                                         <MudStack Spacing="1" AlignItems="AlignItems.Center">
                                                             <MudIcon Icon="@Icons.Material.Filled.Phishing" Color="Color.Primary" Size="Size.Large" />
@@ -609,6 +663,16 @@
                                                     </MudText>
                                                 </MudAlert>
                                             }
+
+                                            <MudAlert Severity="Severity.Warning" Dense="true" Class="mt-2">
+                                                <MudText Typo="Typo.body2">
+                                                    <strong>Economy Impact:</strong>
+                                                    Gross @simulationResult.TotalGold g,
+                                                    Snap Cost @simulationResult.SnapReplacementCostTotal.ToString("F2") g,
+                                                    Net @simulationResult.NetGoldAfterSnapCosts.ToString("F2") g
+                                                    (@simulationResult.NetAverageGoldPerAttempt.ToString("F2") g/attempt)
+                                                </MudText>
+                                            </MudAlert>
                                         </MudExpansionPanel>
                                     </MudExpansionPanels>
                                 }
@@ -1183,8 +1247,6 @@
     // Simulator state
     private bool isSimulating = false;
     private int simIterations = 100;
-    private bool simUseBoostMode = false;
-    private double simBoostMultiplier = 2.0;
     private IReadOnlyCollection<int> simSelectedItems = new HashSet<int>();
     private FishingSimulationResult? simulationResult;
 
@@ -1520,6 +1582,16 @@
     {
         try
         {
+            if (settings.LineSnapChance <= 0 || settings.LineSnapChance > 1)
+            {
+                settings.LineSnapChance = FishingSettings.DefaultLineSnapChance;
+            }
+
+            if (settings.RodSnapChance <= 0 || settings.RodSnapChance > 1)
+            {
+                settings.RodSnapChance = FishingSettings.DefaultRodSnapChance;
+            }
+
             await fishingService.UpdateSettings(settings);
             helpDataService.InvalidateCache(); // Invalidate help data on settings changes
             Snackbar.Add("Settings saved successfully", Severity.Success);
@@ -1634,12 +1706,10 @@
             var selectedItemIds = simSelectedItems.ToList();
             simulationResult = await analyticsService.SimulateFishing(
                 simIterations, 
-                simUseBoostMode, 
-                simBoostMultiplier, 
                 selectedItemIds
             );
 
-            Snackbar.Add($"Simulation complete! {simIterations} catches analyzed.", Severity.Success);
+            Snackbar.Add($"Simulation complete! {simIterations} attempts analyzed using current settings.", Severity.Success);
         }
         catch (Exception ex)
         {

--- a/DotNetTwitchBot/Pages/Fishing/FishingAdmin.razor
+++ b/DotNetTwitchBot/Pages/Fishing/FishingAdmin.razor
@@ -1278,6 +1278,8 @@
         if (loadedSettings != null)
         {
             settings = loadedSettings;
+            settings.LineSnapChance = NormalizeProbability(settings.LineSnapChance, FishingSettings.DefaultLineSnapChance);
+            settings.RodSnapChance = NormalizeProbability(settings.RodSnapChance, FishingSettings.DefaultRodSnapChance);
         }
     }
 
@@ -1582,15 +1584,8 @@
     {
         try
         {
-            if (settings.LineSnapChance <= 0 || settings.LineSnapChance > 1)
-            {
-                settings.LineSnapChance = FishingSettings.DefaultLineSnapChance;
-            }
-
-            if (settings.RodSnapChance <= 0 || settings.RodSnapChance > 1)
-            {
-                settings.RodSnapChance = FishingSettings.DefaultRodSnapChance;
-            }
+            settings.LineSnapChance = NormalizeProbability(settings.LineSnapChance, FishingSettings.DefaultLineSnapChance);
+            settings.RodSnapChance = NormalizeProbability(settings.RodSnapChance, FishingSettings.DefaultRodSnapChance);
 
             await fishingService.UpdateSettings(settings);
             helpDataService.InvalidateCache(); // Invalidate help data on settings changes
@@ -1600,6 +1595,16 @@
         {
             Snackbar.Add($"Error saving settings: {ex.Message}", Severity.Error);
         }
+    }
+
+    private static double NormalizeProbability(double value, double fallback)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+        {
+            return fallback;
+        }
+
+        return Math.Clamp(value, 0.0, 1.0);
     }
 
     private void ShowResetConfirmation()

--- a/DotNetTwitchBot/Pages/Fishing/FishingBalanceAnalysis.razor
+++ b/DotNetTwitchBot/Pages/Fishing/FishingBalanceAnalysis.razor
@@ -114,7 +114,22 @@
                                 </MudStack>
                             </MudPaper>
                         </MudItem>
+                        <MudItem xs="12" sm="6" md="3">
+                            <MudPaper Elevation="2" Class="pa-3">
+                                <MudStack Spacing="1">
+                                    <MudText Typo="Typo.subtitle2" Color="Color.Secondary">Net Gold/Attempt</MudText>
+                                    <MudText Typo="Typo.h4">@report.SnapAdjustedAverageGoldPerAttempt.ToString("N2")</MudText>
+                                </MudStack>
+                            </MudPaper>
+                        </MudItem>
                     </MudGrid>
+                    <MudAlert Severity="Severity.Info" Dense="true">
+                        <MudText Typo="Typo.body2">
+                            Snap model: line @((report.ConfiguredLineSnapChance * 100).ToString("F2"))%, rod @((report.ConfiguredRodSnapChance * 100).ToString("F2"))%,
+                            estimated failures @report.EstimatedFailedAttempts of @report.EstimatedTotalAttempts attempts,
+                            replacement sink @report.EstimatedSnapReplacementCostTotal.ToString("F2")g total.
+                        </MudText>
+                    </MudAlert>
                 </MudStack>
             </MudPaper>
 
@@ -196,6 +211,12 @@
                                     </MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Tertiary">
                                         Mean (Actual): @report.AverageGoldPerCatch.ToString("F2")g/catch
+                                    </MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Tertiary">
+                                        Median (Net w/ snaps): @report.SnapAdjustedMedianGoldPerAttempt.ToString("F2")g/attempt
+                                    </MudText>
+                                    <MudText Typo="Typo.caption" Color="Color.Tertiary">
+                                        Mean (Net w/ snaps): @report.SnapAdjustedAverageGoldPerAttempt.ToString("F2")g/attempt
                                     </MudText>
                                     <MudText Typo="Typo.caption" Color="Color.Tertiary">
                                         Using: @GetPricingGoldSourceDisplay(pricingGoldSource)
@@ -457,7 +478,7 @@
                         </MudAlert>
 
                         <MudText Typo="Typo.body2" Color="Color.Secondary" Class="mb-3">
-                            Calculations based on current average gold/catch (@report.AverageGoldPerCatch.ToString("F1")g). Active player progression shown.
+                            Calculations based on effective net gold/attempt with snaps (@report.SnapAdjustedAverageGoldPerAttempt.ToString("F1")g). Active player progression shown.
                         </MudText>
                         <MudAlert Severity="Severity.Info" Dense="true" Class="mb-3">
                             <MudText Typo="Typo.caption">
@@ -1078,11 +1099,15 @@
             double goldPerCatch;
             if (pricingGoldSource == PricingGoldSource.ReportAverage)
             {
-                goldPerCatch = report.AverageGoldPerCatch;
+                goldPerCatch = report.SnapAdjustedAverageGoldPerAttempt > 0
+                    ? report.SnapAdjustedAverageGoldPerAttempt
+                    : report.AverageGoldPerCatch;
             }
             else if (pricingGoldSource == PricingGoldSource.ReportMedian)
             {
-                goldPerCatch = report.MedianGoldPerCatch;
+                goldPerCatch = report.SnapAdjustedMedianGoldPerAttempt > 0
+                    ? report.SnapAdjustedMedianGoldPerAttempt
+                    : report.MedianGoldPerCatch;
             }
             else if (pricingGoldSource == PricingGoldSource.ProgressiveBaseline)
             {

--- a/DotNetTwitchBot/Pages/Fishing/FishingBalanceAnalysis.razor
+++ b/DotNetTwitchBot/Pages/Fishing/FishingBalanceAnalysis.razor
@@ -1095,19 +1095,15 @@
                 return;
             }
 
-            // Gold-per-catch source for pricing calculations.
+            // Gold source for pricing calculations. Report sources are snap-adjusted net gold/attempt.
             double goldPerCatch;
             if (pricingGoldSource == PricingGoldSource.ReportAverage)
             {
-                goldPerCatch = report.SnapAdjustedAverageGoldPerAttempt > 0
-                    ? report.SnapAdjustedAverageGoldPerAttempt
-                    : report.AverageGoldPerCatch;
+                goldPerCatch = Math.Max(0, report.SnapAdjustedAverageGoldPerAttempt);
             }
             else if (pricingGoldSource == PricingGoldSource.ReportMedian)
             {
-                goldPerCatch = report.SnapAdjustedMedianGoldPerAttempt > 0
-                    ? report.SnapAdjustedMedianGoldPerAttempt
-                    : report.MedianGoldPerCatch;
+                goldPerCatch = Math.Max(0, report.SnapAdjustedMedianGoldPerAttempt);
             }
             else if (pricingGoldSource == PricingGoldSource.ProgressiveBaseline)
             {

--- a/DotNetTwitchBot/wwwroot/fishing.html
+++ b/DotNetTwitchBot/wwwroot/fishing.html
@@ -104,6 +104,10 @@
         .rarity.rare { background: #2196F3; }
         .rarity.epic { background: #9C27B0; }
         .rarity.legendary { background: linear-gradient(45deg, #FFD700, #FFA500); animation: legendary-glow 2s infinite; }
+        .rarity.accident {
+            background: linear-gradient(135deg, #8b1e1e, #d35400);
+            box-shadow: 0 0 18px rgba(211, 84, 0, 0.45);
+        }
 
         @keyframes legendary-glow {
             0%, 100% { box-shadow: 0 0 20px #FFD700; }

--- a/DotNetTwitchBot/wwwroot/js/fishing.js
+++ b/DotNetTwitchBot/wwwroot/js/fishing.js
@@ -94,15 +94,20 @@ async function handleQueue() {
 
 async function handleFishingAlert(fishingData) {
     const {
-        username,
-        fishName,
-        rarity,
-        stars,
-        weight,
-        gold,
-        imageFileName,
+        username = 'Unknown',
+        fishName = 'Unknown Catch',
+        rarity = 'Common',
+        stars = 0,
+        weight = 0,
+        gold = 0,
+        imageFileName = '',
         duration = 5000
-    } = fishingData;
+    } = fishingData ?? {};
+
+    const safeRarity = typeof rarity === 'string' && rarity.length > 0 ? rarity : 'Common';
+    const safeStars = Number.isFinite(stars) ? Math.max(0, Math.floor(stars)) : 0;
+    const safeWeight = Number.isFinite(weight) ? weight : 0;
+    const safeGold = Number.isFinite(gold) ? gold : 0;
 
     $('#username').text(`${username} caught:`);
     $('#fish-name').text(fishName);
@@ -121,21 +126,22 @@ async function handleFishingAlert(fishingData) {
         const baseFileName = fileNameNoExt.replace(/_(thumbnail|small|medium|large)$/i, '');
         audioFile = await findAudioFile(baseFileName);
     } else {
+        fishImage.attr('src', '');
         fishImage.hide();
     }
 
     const rarityElement = $('#rarity');
-    rarityElement.removeClass().addClass('rarity').addClass(rarity.toLowerCase());
-    rarityElement.text(rarity);
+    rarityElement.removeClass().addClass('rarity').addClass(safeRarity.toLowerCase());
+    rarityElement.text(safeRarity);
 
     let starHtml = '';
-    for (let i = 0; i < stars; i++) {
+    for (let i = 0; i < safeStars; i++) {
         starHtml += '<span class="star">★</span>';
     }
     $('#stars').html(starHtml);
 
-    $('#weight').text(`${weight} kg`);
-    $('#gold').text(`${gold} gold`);
+    $('#weight').text(`${safeWeight} kg`);
+    $('#gold').text(`${safeGold} gold`);
 
     await sleep(100);
 

--- a/DotNetTwitchBot/wwwroot/js/fishing.js
+++ b/DotNetTwitchBot/wwwroot/js/fishing.js
@@ -104,10 +104,12 @@ async function handleFishingAlert(fishingData) {
         duration = 5000
     } = fishingData ?? {};
 
-    const safeRarity = typeof rarity === 'string' && rarity.length > 0 ? rarity : 'Common';
-    const safeStars = Number.isFinite(stars) ? Math.max(0, Math.floor(stars)) : 0;
-    const safeWeight = Number.isFinite(weight) ? weight : 0;
-    const safeGold = Number.isFinite(gold) ? gold : 0;
+    const normalizedRarity = normalizeRarity(rarity);
+    const safeRarity = normalizedRarity.label;
+    const safeRarityClass = normalizedRarity.cssClass;
+    const safeStars = Math.max(0, Math.floor(toFiniteNumber(stars, 0)));
+    const safeWeight = toFiniteNumber(weight, 0);
+    const safeGold = toFiniteNumber(gold, 0);
 
     $('#username').text(`${username} caught:`);
     $('#fish-name').text(fishName);
@@ -131,7 +133,7 @@ async function handleFishingAlert(fishingData) {
     }
 
     const rarityElement = $('#rarity');
-    rarityElement.removeClass().addClass('rarity').addClass(safeRarity.toLowerCase());
+    rarityElement.removeClass().addClass('rarity').addClass(safeRarityClass);
     rarityElement.text(safeRarity);
 
     let starHtml = '';
@@ -193,4 +195,36 @@ async function findAudioFile(baseFileName) {
     }
 
     return null;
+}
+
+function toFiniteNumber(value, fallback) {
+    const parsed = typeof value === 'string'
+        ? Number.parseFloat(value.trim())
+        : Number(value);
+
+    return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function normalizeRarity(rarity) {
+    const normalized = typeof rarity === 'string' ? rarity.trim().toLowerCase() : '';
+    const allowedRarities = {
+        common: 'Common',
+        uncommon: 'Uncommon',
+        rare: 'Rare',
+        epic: 'Epic',
+        legendary: 'Legendary',
+        accident: 'Accident'
+    };
+
+    if (allowedRarities[normalized]) {
+        return {
+            label: allowedRarities[normalized],
+            cssClass: normalized
+        };
+    }
+
+    return {
+        label: 'Common',
+        cssClass: 'common'
+    };
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Line-snap and rod-snap outcomes added: can consume/remove equipped fishing items, broadcast snap events, and are tracked in stats.
  * Snap chances configurable in Fishing Settings; admin UI validates/clamps values.
  * Simulator/Admin and Balance pages report snap statistics, show snap-adjusted net gold/attempt and economy impact; simulator now uses saved settings.

* **Refactor**
  * Fishing attempt and analytics flows updated to model snap outcomes alongside normal catches.

* **Tests**
  * Removed test for fish-specific shop item generation; shop item generation coverage adjusted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->