### PR TITLE
Persists Snapped Data and resets with reset user data

### DIFF
--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingGameplayService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingGameplayService.cs
@@ -60,7 +60,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
 
             if (Random.Shared.NextDouble() < rodSnapChance)
             {
-                await _inventoryService.ConsumeItemsOnRodSnap(userId);
+                await _inventoryService.ConsumeItemsOnRodSnap(userId, username);
 
                 try
                 {
@@ -100,7 +100,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
 
             if (Random.Shared.NextDouble() < lineSnapChance)
             {
-                await _inventoryService.ConsumeItemsOnLineSnap(userId);
+                await _inventoryService.ConsumeItemsOnLineSnap(userId, username);
 
                 try
                 {

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingInventoryService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingInventoryService.cs
@@ -1,6 +1,7 @@
 using DotNetTwitchBot.Bot.Core.Database;
 using DotNetTwitchBot.Bot.Models.Fishing;
 using Microsoft.EntityFrameworkCore;
+using System.Text.Json;
 
 namespace DotNetTwitchBot.Bot.Commands.Fishing
 {
@@ -235,24 +236,48 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             await context.SaveChangesAsync();
         }
 
-        public async Task ConsumeItemsOnLineSnap(string userId)
+        public async Task<FishingSnapEvent> ConsumeItemsOnLineSnap(string userId, string username)
         {
             using var scope = _scopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            await ApplySnapLosses(context, userId, includeRodLoss: false);
+
+            var lossResult = await ApplySnapLosses(context, userId, includeRodLoss: false);
+            var snapEvent = BuildSnapEvent(userId, username, "Line", lossResult);
+            context.FishingSnapEvents.Add(snapEvent);
             await context.SaveChangesAsync();
+            return snapEvent;
         }
 
-        public async Task ConsumeItemsOnRodSnap(string userId)
+        public async Task<FishingSnapEvent> ConsumeItemsOnRodSnap(string userId, string username)
         {
             using var scope = _scopeFactory.CreateScope();
             var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            await ApplySnapLosses(context, userId, includeRodLoss: true);
+
+            var lossResult = await ApplySnapLosses(context, userId, includeRodLoss: true);
+            var snapEvent = BuildSnapEvent(userId, username, "Rod", lossResult);
+            context.FishingSnapEvents.Add(snapEvent);
             await context.SaveChangesAsync();
+            return snapEvent;
         }
 
-        private static async Task ApplySnapLosses(ApplicationDbContext context, string userId, bool includeRodLoss)
+        private static FishingSnapEvent BuildSnapEvent(string userId, string username, string snapType, FishingSnapLossResult lossResult)
         {
+            return new FishingSnapEvent
+            {
+                UserId = userId,
+                Username = username,
+                SnapType = snapType,
+                TotalGoldLost = decimal.Round(lossResult.TotalGoldLost, 2, MidpointRounding.AwayFromZero),
+                LostItemCount = lossResult.LostItems.Count,
+                LostItemsJson = JsonSerializer.Serialize(lossResult.LostItems),
+                SnappedAt = DateTime.UtcNow
+            };
+        }
+
+        private static async Task<FishingSnapLossResult> ApplySnapLosses(ApplicationDbContext context, string userId, bool includeRodLoss)
+        {
+            var lossResult = new FishingSnapLossResult();
+
             var equippedItems = await context.UserFishingBoosts
                 .Include(b => b.ShopItem)
                 .Where(b => b.UserId == userId && b.IsEquipped)
@@ -262,6 +287,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             {
                 foreach (var rodItem in equippedItems.Where(i => i.ShopItem?.EquipmentSlot == EquipmentSlot.Rod))
                 {
+                    RegisterFullItemLoss(lossResult, rodItem);
                     context.UserFishingBoosts.Remove(rodItem);
                 }
             }
@@ -278,6 +304,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 // Line/hook are always lost on a snapped line.
                 if (slot == EquipmentSlot.Line || slot == EquipmentSlot.Hook)
                 {
+                    RegisterFullItemLoss(lossResult, item);
                     context.UserFishingBoosts.Remove(item);
                     continue;
                 }
@@ -290,16 +317,25 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                 if (item.RemainingUses == -1)
                 {
                     // Unlimited bait/lure are fully lost on snap.
+                    RegisterFullItemLoss(lossResult, item);
                     context.UserFishingBoosts.Remove(item);
                     continue;
                 }
 
+                var remainingUsesBefore = item.RemainingUses;
                 if (item.RemainingUses > 0)
                 {
                     item.RemainingUses--;
                 }
+                var remainingUsesAfter = item.RemainingUses;
 
                 item.LastUsedAt = DateTime.UtcNow;
+
+                var usesLost = Math.Max(0, remainingUsesBefore - remainingUsesAfter);
+                if (usesLost > 0)
+                {
+                    RegisterUseLoss(lossResult, item, usesLost, remainingUsesBefore, remainingUsesAfter);
+                }
 
                 if (item.ShopItem?.IsConsumable == true && item.RemainingUses <= 0)
                 {
@@ -311,6 +347,70 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
                     item.IsEquipped = false;
                 }
             }
+
+            return lossResult;
+        }
+
+        private static void RegisterFullItemLoss(FishingSnapLossResult lossResult, UserFishingBoost item)
+        {
+            var cost = item.ShopItem?.Cost ?? 0;
+            var valueLost = decimal.Round(cost, 2, MidpointRounding.AwayFromZero);
+
+            lossResult.TotalGoldLost += valueLost;
+            lossResult.LostItems.Add(new FishingSnapLostItem
+            {
+                UserBoostId = item.Id,
+                ShopItemId = item.ShopItemId,
+                ItemName = item.ShopItem?.Name ?? "Unknown Item",
+                EquipmentSlot = item.ShopItem?.EquipmentSlot?.ToString() ?? "Unknown",
+                ItemCostAtSnap = cost,
+                UsesLost = item.RemainingUses == -1 ? -1 : Math.Max(1, item.RemainingUses),
+                RemainingUsesBefore = item.RemainingUses,
+                RemainingUsesAfter = null,
+                ItemRemoved = true,
+                GoldValueLost = valueLost
+            });
+        }
+
+        private static void RegisterUseLoss(
+            FishingSnapLossResult lossResult,
+            UserFishingBoost item,
+            int usesLost,
+            int remainingUsesBefore,
+            int remainingUsesAfter)
+        {
+            var perUseLoss = CalculatePerUseLoss(item.ShopItem);
+            var valueLost = decimal.Round(perUseLoss * usesLost, 2, MidpointRounding.AwayFromZero);
+
+            lossResult.TotalGoldLost += valueLost;
+            lossResult.LostItems.Add(new FishingSnapLostItem
+            {
+                UserBoostId = item.Id,
+                ShopItemId = item.ShopItemId,
+                ItemName = item.ShopItem?.Name ?? "Unknown Item",
+                EquipmentSlot = item.ShopItem?.EquipmentSlot?.ToString() ?? "Unknown",
+                ItemCostAtSnap = item.ShopItem?.Cost ?? 0,
+                UsesLost = usesLost,
+                RemainingUsesBefore = remainingUsesBefore,
+                RemainingUsesAfter = remainingUsesAfter,
+                ItemRemoved = false,
+                GoldValueLost = valueLost
+            });
+        }
+
+        private static decimal CalculatePerUseLoss(FishingShopItem? item)
+        {
+            if (item == null)
+            {
+                return 0m;
+            }
+
+            if (item.MaxUses.HasValue && item.MaxUses.Value > 0)
+            {
+                return (decimal)item.Cost / item.MaxUses.Value;
+            }
+
+            return item.Cost;
         }
     }
 }

--- a/DotNetTwitchBot/Bot/Commands/Fishing/FishingService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/FishingService.cs
@@ -267,6 +267,9 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
             // Remove all user boosts (purchased items)
             await context.UserFishingBoosts.ExecuteDeleteAsync();
 
+            // Remove all user snap history records
+            await context.FishingSnapEvents.ExecuteDeleteAsync();
+
             await context.SaveChangesAsync();
         }
 

--- a/DotNetTwitchBot/Bot/Commands/Fishing/IFishingInventoryService.cs
+++ b/DotNetTwitchBot/Bot/Commands/Fishing/IFishingInventoryService.cs
@@ -13,7 +13,7 @@ namespace DotNetTwitchBot.Bot.Commands.Fishing
         Task EquipItem(string userId, int userBoostId);
         Task UnequipItem(string userId, int userBoostId);
         Task ConsumeItemUse(string userId, int userBoostId);
-        Task ConsumeItemsOnLineSnap(string userId);
-        Task ConsumeItemsOnRodSnap(string userId);
+        Task<FishingSnapEvent> ConsumeItemsOnLineSnap(string userId, string username);
+        Task<FishingSnapEvent> ConsumeItemsOnRodSnap(string userId, string username);
     }
 }

--- a/DotNetTwitchBot/Bot/Core/Database/ApplicationDbContext.cs
+++ b/DotNetTwitchBot/Bot/Core/Database/ApplicationDbContext.cs
@@ -63,6 +63,7 @@ namespace DotNetTwitchBot.Bot.Core.Database
         // Fishing tables
         public DbSet<FishType> FishTypes { get; set; } = null!;
         public DbSet<FishCatch> FishCatches { get; set; } = null!;
+        public DbSet<FishingSnapEvent> FishingSnapEvents { get; set; } = null!;
         public DbSet<FishingGold> FishingGolds { get; set; } = null!;
         public DbSet<FishingShopItem> FishingShopItems { get; set; } = null!;
         public DbSet<UserFishingBoost> UserFishingBoosts { get; set; } = null!;
@@ -149,6 +150,28 @@ namespace DotNetTwitchBot.Bot.Core.Database
             modelBuilder.Entity<FishCatch>()
                 .HasIndex(e => new { e.UserId, e.CaughtAt })
                 .HasDatabaseName("IX_FishCatches_UserId_CaughtAt");
+
+            modelBuilder.Entity<FishingSnapEvent>()
+                .Property(e => e.UserId)
+                .HasMaxLength(255)
+                .IsRequired();
+
+            modelBuilder.Entity<FishingSnapEvent>()
+                .Property(e => e.SnapType)
+                .HasMaxLength(16)
+                .IsRequired();
+
+            modelBuilder.Entity<FishingSnapEvent>()
+                .Property(e => e.TotalGoldLost)
+                .HasColumnType("decimal(18,2)");
+
+            modelBuilder.Entity<FishingSnapEvent>()
+                .HasIndex(e => new { e.UserId, e.SnappedAt })
+                .HasDatabaseName("IX_FishingSnapEvents_UserId_SnappedAt");
+
+            modelBuilder.Entity<FishingSnapEvent>()
+                .HasIndex(e => new { e.SnapType, e.SnappedAt })
+                .HasDatabaseName("IX_FishingSnapEvents_SnapType_SnappedAt");
         }
     }
 }

--- a/DotNetTwitchBot/Bot/DatabaseTools/BackupTools.cs
+++ b/DotNetTwitchBot/Bot/DatabaseTools/BackupTools.cs
@@ -127,7 +127,8 @@ namespace DotNetTwitchBot.Bot.DatabaseTools
                 { "FishCatchRepository", 12 },     // FishCatch (depends on FishType)
                 { "UserFishingBoostRepository", 13 }, // UserFishingBoost (depends on FishingShopItem)
                 { "FishingGoldRepository", 14 },   // FishingGold (no dependencies)
-                { "FishingSettingsRepository", 15 } // FishingSettings (no dependencies)
+                { "FishingSettingsRepository", 15 }, // FishingSettings (no dependencies)
+                { "FishingSnapEventRepository", 16 } // FishingSnapEvent (historical, no dependencies)
             };
 
             // Sort handlers by priority

--- a/DotNetTwitchBot/Bot/Models/Fishing/FishingSnapEvent.cs
+++ b/DotNetTwitchBot/Bot/Models/Fishing/FishingSnapEvent.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace DotNetTwitchBot.Bot.Models.Fishing
+{
+    public class FishingSnapEvent
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [MaxLength(255)]
+        public string UserId { get; set; } = string.Empty;
+
+        public string Username { get; set; } = string.Empty;
+
+        [MaxLength(16)]
+        public string SnapType { get; set; } = "Line";
+
+        public decimal TotalGoldLost { get; set; }
+
+        public int LostItemCount { get; set; }
+
+        public string LostItemsJson { get; set; } = "[]";
+
+        public DateTime SnappedAt { get; set; } = DateTime.UtcNow;
+    }
+
+    public class FishingSnapLossResult
+    {
+        public decimal TotalGoldLost { get; set; }
+        public List<FishingSnapLostItem> LostItems { get; set; } = new();
+    }
+
+    public class FishingSnapLostItem
+    {
+        public int UserBoostId { get; set; }
+        public int ShopItemId { get; set; }
+        public string ItemName { get; set; } = string.Empty;
+        public string EquipmentSlot { get; set; } = string.Empty;
+        public int ItemCostAtSnap { get; set; }
+        public int UsesLost { get; set; }
+        public int? RemainingUsesBefore { get; set; }
+        public int? RemainingUsesAfter { get; set; }
+        public bool ItemRemoved { get; set; }
+        public decimal GoldValueLost { get; set; }
+    }
+}

--- a/DotNetTwitchBot/Migrations/20260505201317_AddFishingSnapEvents.Designer.cs
+++ b/DotNetTwitchBot/Migrations/20260505201317_AddFishingSnapEvents.Designer.cs
@@ -4,6 +4,7 @@ using DotNetTwitchBot.Bot.Core.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace DotNetTwitchBot.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260505201317_AddFishingSnapEvents")]
+    partial class AddFishingSnapEvents
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/DotNetTwitchBot/Migrations/20260505201317_AddFishingSnapEvents.cs
+++ b/DotNetTwitchBot/Migrations/20260505201317_AddFishingSnapEvents.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace DotNetTwitchBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFishingSnapEvents : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "FishingSnapEvents",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "int", nullable: false)
+                        .Annotation("MySql:ValueGenerationStrategy", MySqlValueGenerationStrategy.IdentityColumn),
+                    UserId = table.Column<string>(type: "varchar(255)", maxLength: 255, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    Username = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    SnapType = table.Column<string>(type: "varchar(16)", maxLength: 16, nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    TotalGoldLost = table.Column<decimal>(type: "decimal(18,2)", nullable: false),
+                    LostItemCount = table.Column<int>(type: "int", nullable: false),
+                    LostItemsJson = table.Column<string>(type: "longtext", nullable: false)
+                        .Annotation("MySql:CharSet", "utf8mb4"),
+                    SnappedAt = table.Column<DateTime>(type: "datetime(6)", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_FishingSnapEvents", x => x.Id);
+                })
+                .Annotation("MySql:CharSet", "utf8mb4");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FishingSnapEvents_SnapType_SnappedAt",
+                table: "FishingSnapEvents",
+                columns: new[] { "SnapType", "SnappedAt" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_FishingSnapEvents_UserId_SnappedAt",
+                table: "FishingSnapEvents",
+                columns: new[] { "UserId", "SnappedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "FishingSnapEvents");
+        }
+    }
+}

--- a/DotNetTwitchBot/Repository/IFishingRepository.cs
+++ b/DotNetTwitchBot/Repository/IFishingRepository.cs
@@ -25,4 +25,8 @@ namespace DotNetTwitchBot.Repository
     public interface IFishingSettingsRepository : IGenericRepository<FishingSettings>
     {
     }
+
+    public interface IFishingSnapEventRepository : IGenericRepository<FishingSnapEvent>
+    {
+    }
 }

--- a/DotNetTwitchBot/Repository/IUnitOfWork.cs
+++ b/DotNetTwitchBot/Repository/IUnitOfWork.cs
@@ -65,5 +65,6 @@
         IFishingShopItemRepository FishingShopItems { get; }
         IUserFishingBoostRepository UserFishingBoosts { get; }
         IFishingSettingsRepository FishingSettings { get; }
+        IFishingSnapEventRepository FishingSnapEvents { get; }
     }
 }

--- a/DotNetTwitchBot/Repository/Repositories/FishingRepositories.cs
+++ b/DotNetTwitchBot/Repository/Repositories/FishingRepositories.cs
@@ -77,6 +77,10 @@ namespace DotNetTwitchBot.Repository.Repositories
             // Delete in reverse order: children before parents
             // This avoids foreign key constraint violations
 
+            // 0. Delete FishingSnapEvents (independent historical table)
+            logger?.LogDebug("Deleting FishingSnapEvents...");
+            await context.Set<FishingSnapEvent>().ExecuteDeleteAsync();
+
             // 1. Delete UserFishingBoosts (depends on FishingShopItems)
             logger?.LogDebug("Deleting UserFishingBoosts...");
             await context.Set<UserFishingBoost>().ExecuteDeleteAsync();
@@ -373,6 +377,56 @@ namespace DotNetTwitchBot.Repository.Repositories
             catch (Exception ex)
             {
                 logger?.LogError(ex, "Failed to restore {Name}", typeof(FishingSettings).Name);
+                throw;
+            }
+        }
+    }
+
+    /// <summary>
+    /// FishingSnapEvent repository - Depends on no foreign keys.
+    /// NOTE: Deletion happens in FishingRepository to maintain proper order.
+    /// </summary>
+    public class FishingSnapEventRepository : GenericRepository<FishingSnapEvent>, IFishingSnapEventRepository
+    {
+        public FishingSnapEventRepository(ApplicationDbContext context) : base(context)
+        {
+        }
+
+        public override async Task RestoreTable(DbContext context, string backupDirectory, ILogger? logger = null)
+        {
+            try
+            {
+                var fileName = $"{backupDirectory}/{typeof(FishingSnapEvent).Name}.json";
+                if (!File.Exists(fileName))
+                {
+                    logger?.LogDebug("No backup file found for {Name}", typeof(FishingSnapEvent).Name);
+                    return;
+                }
+
+                var json = await File.ReadAllTextAsync(fileName, encoding: System.Text.Encoding.UTF8);
+
+                var options = new JsonSerializerOptions
+                {
+                    ReferenceHandler = System.Text.Json.Serialization.ReferenceHandler.IgnoreCycles
+                };
+
+                var records = JsonSerializer.Deserialize<List<FishingSnapEvent>>(json, options);
+                if (records == null) throw new Exception($"{typeof(FishingSnapEvent).Name}.json was null");
+
+                foreach (var record in records)
+                {
+                    var entry = context.Entry(record);
+                    entry.State = EntityState.Added;
+                }
+
+                await context.SaveChangesAsync();
+                context.ChangeTracker.Clear();
+
+                logger?.LogDebug("Restored {Count} FishingSnapEvent records", records.Count);
+            }
+            catch (Exception ex)
+            {
+                logger?.LogError(ex, "Failed to restore {Name}", typeof(FishingSnapEvent).Name);
                 throw;
             }
         }

--- a/DotNetTwitchBot/Repository/UnitOfWork.cs
+++ b/DotNetTwitchBot/Repository/UnitOfWork.cs
@@ -68,6 +68,7 @@ namespace DotNetTwitchBot.Repository
             FishingShopItems = new FishingShopItemRepository(_context);
             UserFishingBoosts = new UserFishingBoostRepository(_context);
             FishingSettings = new FishingSettingsRepository(_context);
+            FishingSnapEvents = new FishingSnapEventRepository(_context);
         }
 
         public IAudioCommandsRepository AudioCommands { get; private set; }
@@ -129,6 +130,7 @@ namespace DotNetTwitchBot.Repository
         public IFishingShopItemRepository FishingShopItems { get; private set; }
         public IUserFishingBoostRepository UserFishingBoosts { get; private set; }
         public IFishingSettingsRepository FishingSettings { get; private set; }
+        public IFishingSnapEventRepository FishingSnapEvents { get; private set; }
 
         public void Dispose()
         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fishing snap events (rod and line breaks) are now tracked and recorded in your game history.
  * Detailed snap records persist, including items lost and gold costs.
  * Snap event history is included in backup and restore operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->