### PR TITLE
Move TwitchLib to nugets

### DIFF
--- a/.github/workflows/dotnet-win.yml
+++ b/.github/workflows/dotnet-win.yml
@@ -24,6 +24,9 @@ jobs:
       with:
         dotnet-version: 9.0.x
         submodules: recursive
+    - name: Pack TwitchLib local packages
+      run: pack-twitchlib.bat
+      shell: cmd
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -27,6 +27,18 @@ jobs:
       with:
         dotnet-version: 9.0.x
         submodules: recursive
+    - name: Pack TwitchLib local packages
+      run: |
+        OUTPUT="LocalPackages"
+        dotnet pack TwitchLib.EventSub.Core/TwitchLib.EventSub.Core/TwitchLib.EventSub.Core.csproj -o "$OUTPUT" -c Release
+        dotnet pack TwitchLib.Api/TwitchLib.Api.Core.Enums/TwitchLib.Api.Core.Enums.csproj -o "$OUTPUT" -c Release
+        dotnet pack TwitchLib.Api/TwitchLib.Api.Core.Interfaces/TwitchLib.Api.Core.Interfaces.csproj -o "$OUTPUT" -c Release
+        dotnet pack TwitchLib.Api/TwitchLib.Api.Core.Models/TwitchLib.Api.Core.Models.csproj -o "$OUTPUT" -c Release
+        dotnet pack TwitchLib.Api/TwitchLib.Api.Core/TwitchLib.Api.Core.csproj -o "$OUTPUT" -c Release
+        dotnet pack TwitchLib.Api/TwitchLib.Api.Helix.Models/TwitchLib.Api.Helix.Models.csproj -o "$OUTPUT" -c Release
+        dotnet pack TwitchLib.Api/TwitchLib.Api.Helix/TwitchLib.Api.Helix.csproj -o "$OUTPUT" -c Release
+        dotnet pack TwitchLib.Api/TwitchLib.Api/TwitchLib.Api.csproj -o "$OUTPUT" -c Release
+        dotnet pack TwitchLib.EventSub.Websockets/TwitchLib.EventSub.Websockets/TwitchLib.EventSub.Websockets.csproj -o "$OUTPUT" -c Release
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/DotNetTwitchBot/DotNetTwitchBot.csproj
+++ b/DotNetTwitchBot/DotNetTwitchBot.csproj
@@ -110,8 +110,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\TwitchLib.Api\TwitchLib.Api\TwitchLib.Api.csproj" />
-    <ProjectReference Include="..\TwitchLib.EventSub.Websockets\TwitchLib.EventSub.Websockets\TwitchLib.EventSub.Websockets.csproj" />
+    <PackageReference Include="TwitchLib.Api" Version="3.11.0" />
+    <PackageReference Include="TwitchLib.EventSub.Websockets" Version="0.8.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/LocalPackages/README.txt
+++ b/LocalPackages/README.txt
@@ -1,0 +1,3 @@
+This directory holds locally-packed NuGet packages for TwitchLib.
+Run pack-twitchlib.bat from the repo root to populate it.
+Add LocalPackages/*.nupkg to .gitignore to avoid committing build artifacts.

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+    <add key="LocalPackages" value="LocalPackages" />
+  </packageSources>
+
+  <!--
+    packageSourceMapping ensures all TwitchLib.* packages come exclusively from the
+    local feed. Run pack-twitchlib.bat to rebuild them whenever you update the sources.
+  -->
+  <packageSourceMapping>
+    <packageSource key="LocalPackages">
+      <package pattern="TwitchLib.*" />
+    </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*" />
+    </packageSource>
+  </packageSourceMapping>
+</configuration>

--- a/pack-twitchlib.bat
+++ b/pack-twitchlib.bat
@@ -1,0 +1,66 @@
+@echo off
+setlocal
+
+set SCRIPT_DIR=%~dp0
+set OUTPUT=%SCRIPT_DIR%LocalPackages
+
+echo Packing TwitchLib packages to: %OUTPUT%
+echo.
+
+rem -----------------------------------------------------------------------
+rem TwitchLib.EventSub.Core (leaf - no local TwitchLib deps)
+rem -----------------------------------------------------------------------
+echo [1/9] Packing TwitchLib.EventSub.Core...
+dotnet pack "%SCRIPT_DIR%TwitchLib.EventSub.Core\TwitchLib.EventSub.Core\TwitchLib.EventSub.Core.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+rem -----------------------------------------------------------------------
+rem TwitchLib.Api sub-projects (in dependency order)
+rem -----------------------------------------------------------------------
+echo [2/9] Packing TwitchLib.Api.Core.Enums...
+dotnet pack "%SCRIPT_DIR%TwitchLib.Api\TwitchLib.Api.Core.Enums\TwitchLib.Api.Core.Enums.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+echo [3/9] Packing TwitchLib.Api.Core.Interfaces...
+dotnet pack "%SCRIPT_DIR%TwitchLib.Api\TwitchLib.Api.Core.Interfaces\TwitchLib.Api.Core.Interfaces.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+echo [4/9] Packing TwitchLib.Api.Core.Models...
+dotnet pack "%SCRIPT_DIR%TwitchLib.Api\TwitchLib.Api.Core.Models\TwitchLib.Api.Core.Models.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+echo [5/9] Packing TwitchLib.Api.Core...
+dotnet pack "%SCRIPT_DIR%TwitchLib.Api\TwitchLib.Api.Core\TwitchLib.Api.Core.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+echo [6/9] Packing TwitchLib.Api.Helix.Models...
+dotnet pack "%SCRIPT_DIR%TwitchLib.Api\TwitchLib.Api.Helix.Models\TwitchLib.Api.Helix.Models.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+echo [7/9] Packing TwitchLib.Api.Helix...
+dotnet pack "%SCRIPT_DIR%TwitchLib.Api\TwitchLib.Api.Helix\TwitchLib.Api.Helix.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+echo [8/9] Packing TwitchLib.Api...
+dotnet pack "%SCRIPT_DIR%TwitchLib.Api\TwitchLib.Api\TwitchLib.Api.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+rem -----------------------------------------------------------------------
+rem TwitchLib.EventSub.Websockets (after EventSub.Core is in the feed)
+rem -----------------------------------------------------------------------
+echo [9/9] Packing TwitchLib.EventSub.Websockets...
+dotnet pack "%SCRIPT_DIR%TwitchLib.EventSub.Websockets\TwitchLib.EventSub.Websockets\TwitchLib.EventSub.Websockets.csproj" ^
+    -o "%OUTPUT%" -c Release
+if %ERRORLEVEL% neq 0 (echo FAILED & exit /b %ERRORLEVEL%)
+
+echo.
+echo All packages packed successfully to: %OUTPUT%
+echo You can now build DotNetTwitchBot normally.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipelines with automated local library packaging steps for both Windows and Linux builds
  * Updated dependency configuration to utilize versioned package releases (TwitchLib.Api v3.11.0, TwitchLib.EventSub.Websockets v0.8.0) instead of direct project references
  * Established local NuGet package source with routing rules for improved dependency management and build consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Psychoboy/PenguinTwitchBot/pull/928?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->