### PR TITLE
Clean up and make raid history view sortable

### DIFF
--- a/PenguinTwitchBot/Pages/IntegrationSettings.razor
+++ b/PenguinTwitchBot/Pages/IntegrationSettings.razor
@@ -17,7 +17,7 @@
         Changes are written to <code>appsettings.secrets.json</code> and take effect after restarting the bot.
     </MudAlert>
 
-    <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true" PanelClass="pa-6">
+    <MudTabs Elevation="2" Rounded="true" ApplyEffectsToContainer="true">
 
         <!-- ── YouTube ──────────────────────────────────────────────────── -->
         <MudTabPanel Text="YouTube" Icon="@Icons.Material.Filled.OndemandVideo">

--- a/PenguinTwitchBot/Pages/RaidHistory.razor
+++ b/PenguinTwitchBot/Pages/RaidHistory.razor
@@ -6,41 +6,123 @@
 
 @if (raidHistory != null)
 {
-    <MudTable Items="@(GetFilteredContent())">
-        <HeaderContent>
-            <MudTh>Name</MudTh>
-            <MudTh><MudCheckBox @bind-Value="OnlineOnly">Online?</MudCheckBox></MudTh>
-            <MudTh>Game</MudTh>
-            <MudTh>Incoming Raids</MudTh>
-            <MudTh>Avg. Per</MudTh>
-            <MudTh>Last Incoming</MudTh>
-            <MudTh>Outgoing</MudTh>
-            <MudTh>Avg. Per</MudTh>
-            <MudTh>Last Outgoing</MudTh>
-            <MudTh>Raid</MudTh>
-            <MudTh>Remove</MudTh>
-        </HeaderContent>
-        <RowTemplate>
-            <MudTd DataLabel="Name"><MudLink Href=@LinkBuilder(context.DisplayName) Target="_blank">@context.DisplayName</MudLink></MudTd>
-            <MudTd DataLabel="Is Online">@context.IsOnline</MudTd>
-            <MudTd DataLabel="Game">@context.LastGame</MudTd>
-            <MudTd DataLabel="Incoming">@context.TotalIncomingRaids</MudTd>
-            <MudTd DataLabel="Avg. Incoming"> @(context.TotalIncomingRaids > 0 ? context.TotalIncomingRaidViewers /
-            context.TotalIncomingRaids : 0) </MudTd>
-            <MudTd DataLabel="Last Incoming">@context.LastIncomingRaid.ToShortDateString()</MudTd>
-            <MudTd DataLabel="Outgoing">@context.TotalOutgoingRaids</MudTd>
-            <MudTd DataLabel="Avg. Per"> @(context.TotalOutgoingRaids > 0 ? context.TotalOutGoingRaidViewers /
-            context.TotalOutgoingRaids : 0)</MudTd>
-            <MudTd DataLabel="Last Outgoing">@context.LastOutgoingRaid.ToShortDateString()</MudTd>
-                <MudTd DataLabel="Edit">
-                    <MudButton Variant="Variant.Filled" Color="Color.Primary" @onclick="() => Raid(context)">Raid</MudButton>
-                
-                </MudTd>
-                <MudTd DataLabel="Remove">
-                <MudButton Variant="Variant.Filled" Color="Color.Secondary" @onclick="() => Remove(context)">Remove</MudButton>
-                </MudTd>
-            </RowTemplate>
-        </MudTable>
+<MudContainer Class="pa-2 pa-md-3" MaxWidth="MaxWidth.ExtraExtraLarge">
+    <MudStack Spacing="2">
+        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+            <MudText Typo="Typo.h5">Raid History</MudText>
+            <MudSpacer />
+            <MudText Typo="Typo.body2" Color="Color.Secondary">@GetFilteredContent()?.Count creator(s)</MudText>
+        </MudStack>
+        <MudPaper Elevation="1">
+            <MudTable Items="@(GetFilteredContent())" Dense="true" Hover="true" SortLabel="Name" FixedHeader="true" Height="65vh">
+                <ToolBarContent>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="pa-2">
+                        <MudText Typo="Typo.subtitle1">Raid Statistics</MudText>
+                        <MudSpacer />
+                        <MudCheckBox @bind-Value="OnlineOnly" Label="Online only" Color="Color.Primary" Dense="true" />
+                    </MudStack>
+                </ToolBarContent>
+                <HeaderContent>
+                    <MudTh>
+                        <MudTableSortLabel SortBy="new Func<RaidHistoryEntry, object>(x => x.DisplayName)">
+                            Name
+                        </MudTableSortLabel>
+                    </MudTh>
+                    <MudTh>
+                        Online
+                    </MudTh>
+                    <MudTh>
+                        <MudTableSortLabel SortBy="new Func<RaidHistoryEntry, object>(x => x.LastGame ?? string.Empty)">
+                            Game
+                        </MudTableSortLabel>
+                    </MudTh>
+                    <MudTh>
+                        <MudTableSortLabel SortBy="new Func<RaidHistoryEntry, object>(x => x.TotalIncomingRaids)" InitialDirection="SortDirection.Descending">
+                            Incoming
+                        </MudTableSortLabel>
+                    </MudTh>
+                    <MudTh>
+                        <MudTableSortLabel SortBy="new Func<RaidHistoryEntry, object>(x => x.TotalIncomingRaids > 0 ? x.TotalIncomingRaidViewers / x.TotalIncomingRaids : 0)" InitialDirection="SortDirection.Descending">
+                            Avg In.
+                        </MudTableSortLabel>
+                    </MudTh>
+                    <MudTh>
+                        <MudTableSortLabel SortBy="new Func<RaidHistoryEntry, object>(x => x.LastIncomingRaid)" InitialDirection="SortDirection.Descending">
+                            Last In.
+                        </MudTableSortLabel>
+                    </MudTh>
+                    <MudTh>
+                        <MudTableSortLabel SortBy="new Func<RaidHistoryEntry, object>(x => x.TotalOutgoingRaids)" InitialDirection="SortDirection.Descending">
+                            Outgoing
+                        </MudTableSortLabel>
+                    </MudTh>
+                    <MudTh>
+                        <MudTableSortLabel SortBy="new Func<RaidHistoryEntry, object>(x => x.TotalOutgoingRaids > 0 ? x.TotalOutGoingRaidViewers / x.TotalOutgoingRaids : 0)" InitialDirection="SortDirection.Descending">
+                            Avg Out.
+                        </MudTableSortLabel>
+                    </MudTh>
+                    <MudTh>
+                        <MudTableSortLabel SortBy="new Func<RaidHistoryEntry, object>(x => x.LastOutgoingRaid)" InitialDirection="SortDirection.Descending">
+                            Last Out.
+                        </MudTableSortLabel>
+                    </MudTh>
+                    <MudTh>
+                        Actions
+                    </MudTh>
+                </HeaderContent>
+                <RowTemplate>
+                    <MudTd DataLabel="Name">
+                        <MudLink Href=@LinkBuilder(context.DisplayName) Target="_blank">
+                            <strong>@context.DisplayName</strong>
+                        </MudLink>
+                    </MudTd>
+                    <MudTd DataLabel="Online">
+                        @if (context.IsOnline)
+                        {
+                            <MudChip T="string" Color="Color.Success" Size="Size.Small">Online</MudChip>
+                        }
+                        else
+                        {
+                            <MudChip T="string" Color="Color.Default" Size="Size.Small">Offline</MudChip>
+                        }
+                    </MudTd>
+                    <MudTd DataLabel="Game">
+                        @context.LastGame
+                    </MudTd>
+                    <MudTd DataLabel="Incoming">
+                        <strong>@context.TotalIncomingRaids</strong>
+                    </MudTd>
+                    <MudTd DataLabel="Avg In.">
+                        @(context.TotalIncomingRaids > 0 ? (context.TotalIncomingRaidViewers / context.TotalIncomingRaids).ToString("N0") : "0")
+                    </MudTd>
+                    <MudTd DataLabel="Last In.">
+                        @context.LastIncomingRaid.ToString("yyyy-MM-dd")
+                    </MudTd>
+                    <MudTd DataLabel="Outgoing">
+                        <strong>@context.TotalOutgoingRaids</strong>
+                    </MudTd>
+                    <MudTd DataLabel="Avg Out.">
+                        @(context.TotalOutgoingRaids > 0 ? (context.TotalOutGoingRaidViewers / context.TotalOutgoingRaids).ToString("N0") : "0")
+                    </MudTd>
+                    <MudTd DataLabel="Last Out.">
+                        @context.LastOutgoingRaid.ToString("yyyy-MM-dd")
+                    </MudTd>
+                    <MudTd DataLabel="Actions">
+                        <MudStack Row="true" Spacing="1">
+                            <MudButton Variant="Variant.Text" Color="Color.Primary" Size="Size.Small" @onclick="() => Raid(context)">Raid</MudButton>
+                            <MudButton Variant="Variant.Text" Color="Color.Error" Size="Size.Small" @onclick="() => Remove(context)">Remove</MudButton>
+                        </MudStack>
+                    </MudTd>
+                </RowTemplate>
+                <NoRecordsContent>
+                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.Info">
+                        No raid history available
+                    </MudAlert>
+                </NoRecordsContent>
+            </MudTable>
+        </MudPaper>
+    </MudStack>
+</MudContainer>
 }
 
 @code {

--- a/PenguinTwitchBot/Pages/RaidHistory.razor
+++ b/PenguinTwitchBot/Pages/RaidHistory.razor
@@ -72,7 +72,7 @@
                 </HeaderContent>
                 <RowTemplate>
                     <MudTd DataLabel="Name">
-                        <MudLink Href=@LinkBuilder(context.DisplayName) Target="_blank">
+                        <MudLink Href=@LinkBuilder(context.Name) Target="_blank">
                             <strong>@context.DisplayName</strong>
                         </MudLink>
                     </MudTd>


### PR DESCRIPTION
This pull request significantly improves the `RaidHistory.razor` page by enhancing the UI/UX, adding sorting and statistics features, and modernizing how raid history is presented. There is also a minor cleanup in the `IntegrationSettings.razor` file.

**Raid History UI and Functionality Improvements:**

- Redesigned the raid history table with a new layout using `MudContainer`, `MudStack`, and `MudPaper` for better spacing, structure, and responsiveness. Added a page header and a summary of the number of creators.
- Enhanced the table with sortable columns using `MudTableSortLabel`, allowing users to sort by name, game, incoming/outgoing raids, averages, and timestamps.
- Improved the display of online status with colored chips, formatted numbers with thousands separators, and date formatting for raid timestamps.
- Added a toolbar with a statistics label and a checkbox to filter for "Online only" creators.
- Updated the actions column to use compact, text-style buttons for "Raid" and "Remove" actions, and added a friendly message when no raid history is available.

**Minor UI Cleanup:**

- Removed the unused `PanelClass` property from the `MudTabs` component in `IntegrationSettings.razor` for cleaner markup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted padding layout in Integration Settings panel.

* **New Features**
  * Raid History interface redesigned with sortable columns and fixed headers.
  * Added constrained table height for improved scrolling experience.
  * Introduced "Online only" filter for Raid Statistics.
  * Consolidated action controls into a single Actions column.
  * Enhanced online status with color-coded visual indicators.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Psychoboy/PenguinTwitchBot/pull/953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->