### PR TITLE
Fix raid tracker to use ID instead of name for outgoing

### DIFF
--- a/PenguinTwitchBot/Bot/Commands/Misc/RaidTracker.cs
+++ b/PenguinTwitchBot/Bot/Commands/Misc/RaidTracker.cs
@@ -182,7 +182,7 @@ namespace PenguinTwitchBot.Bot.Commands.Misc
                 await using (var scope = _scopeFactory.CreateAsyncScope())
                 {
                     var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-                    var raidHistory = await db.RaidHistory.Find(x => x.Name.Equals(user.Login)).FirstOrDefaultAsync();
+                    var raidHistory = await db.RaidHistory.Find(x => x.UserId.Equals(user.Id)).FirstOrDefaultAsync();
                     raidHistory ??= new RaidHistoryEntry
                     {
                         UserId = user.Id,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed raid history tracking to correctly match user records using unique identifiers, ensuring accurate aggregation of raid counters and viewer statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->