### PR TITLE
Fixes #1002 and #1003

### DIFF
--- a/PenguinTwitchBot/Bot/Commands/PastyGames/Roll.cs
+++ b/PenguinTwitchBot/Bot/Commands/PastyGames/Roll.cs
@@ -59,33 +59,34 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
             var dice1 = StaticTools.RandomRange(1, 6);
             var dice2 = StaticTools.RandomRange(1, 6);
             var resultMessage = string.Format("{0} rolls a [{1}] and [{2}]. ", e.DisplayName, dice1, dice2);
+            var pointType = await pointsSystem.GetPointTypeForGame(ModuleName);
             if (dice1 == dice2)
             {
                 string prizeName = "";
                 switch (dice1)
                 {
                     case 1:
-                        resultMessage += string.Format("Snake eyes for {0} pasties! ", prizes[0]);
+                        resultMessage += string.Format("Snake eyes for {0} {1}! ", prizes[0], pointType.Name);
                         prizeName = "Snake eyes";
                         break;
                     case 2:
-                        resultMessage += string.Format("Hard four for {0} pasties! ", prizes[1]);
+                        resultMessage += string.Format("Hard four for {0} {1}! ", prizes[1], pointType.Name);
                         prizeName = "Hard four";
                         break;
                     case 3:
-                        resultMessage += string.Format("Hard six for {0} pasties! ", prizes[2]);
+                        resultMessage += string.Format("Hard six for {0} {1}! ", prizes[2], pointType.Name);
                         prizeName = "Hard six";
                         break;
                     case 4:
-                        resultMessage += string.Format("Hard eight for {0} pasties! ", prizes[3]);
+                        resultMessage += string.Format("Hard eight for {0} {1}! ", prizes[3], pointType.Name);
                         prizeName = "Hard eight";
                         break;
                     case 5:
-                        resultMessage += string.Format("Hard ten for {0} pasties! ", prizes[4]);
+                        resultMessage += string.Format("Hard ten for {0} {1}! ", prizes[4], pointType.Name);
                         prizeName = "Hard ten";
                         break;
                     case 6:
-                        resultMessage += string.Format("Boxcars to the max!!! {0} pasties! ", prizes[5]);
+                        resultMessage += string.Format("Boxcars to the max!!! {0} {1}! ", prizes[5], pointType.Name);
                         prizeName = "Boxcars";
                         break;
                 }

--- a/PenguinTwitchBot/Bot/Commands/PastyGames/Slots.cs
+++ b/PenguinTwitchBot/Bot/Commands/PastyGames/Slots.cs
@@ -60,7 +60,7 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
             var e2 = GetEmoteKey();
             var e3 = GetEmoteKey();
             var message = string.Format("{0}: [ {1} {2} {3} ] ", e.DisplayName, Emotes[e1], Emotes[e2], Emotes[e3]);
-
+            var pointType = await pointsSystem.GetPointTypeForGame(ModuleName);
             if (e1 == e2 && e2 == e3) // 3 of a kind
             {
                 var prizeWinnings = Prizes[e1];
@@ -69,7 +69,7 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
                     prizeWinnings = Convert.ToInt64(amount * await gameSettingsService.GetDoubleSetting(ModuleName, GAMESETTING_3_OF_A_KIND, 3.5));
                 }
 
-                message += string.Format("{0} pasties. ", prizeWinnings.ToString("N0"));
+                message += string.Format("{0} {1}. ", prizeWinnings.ToString("N0"), pointType.Name);
                 var randomMessage = WinMessages[StaticTools.Next(0, WinMessages.Count)];
                 message += randomMessage.Replace("{NAME_HERE}", e.DisplayName);
 
@@ -101,8 +101,8 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
                         Convert.ToInt64(amount * await gameSettingsService.GetDoubleSetting(ModuleName, GAMESETTING_FIRST_2_MULTIPLIER, 2.5)) : 
                         Convert.ToInt64(amount * await gameSettingsService.GetDoubleSetting(ModuleName, GAMESETTING_LAST_2_MULTIPLIER, 1.5));
                 }
-
-                message += string.Format("{0} pasties. ", prizeWinnings.ToString("N0"));
+                
+                message += string.Format("{0} {1}. ", prizeWinnings.ToString("N0"), pointType.Name);
                 var randomMessage = WinMessages[StaticTools.Next(0, WinMessages.Count)];
                 message += randomMessage.Replace("{NAME_HERE}", e.DisplayName);
 

--- a/PenguinTwitchBot/Bot/Commands/PastyGames/Steal.cs
+++ b/PenguinTwitchBot/Bot/Commands/PastyGames/Steal.cs
@@ -44,10 +44,12 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
                 throw new SkipCooldownException();
             }
 
+            var pointType = await pointsSystem.GetPointTypeForGame(ModuleName);
+
             var userPasties = await pointsSystem.GetUserPointsByUserIdAndGame(e.UserId, ModuleName);
             if (userPasties.Points < StealMax)
             {
-                await ServiceBackbone.ResponseWithMessage(e, string.Format("you don't have enough pasties to steal, you need a minimum of {0}", StealMax));
+                await ServiceBackbone.ResponseWithMessage(e, string.Format("you don't have enough {0} to steal, you need a minimum of {1}", pointType.Name, StealMax));
                 throw new SkipCooldownException();
             }
 
@@ -59,10 +61,11 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
             var targetPasties = await pointsSystem.GetUserPointsByUsernameAndGame(e.TargetUser, ModuleName);
             var targetDisplayName = await viewerFeature.GetNameWithTitle(e.TargetUser);
             var amount = StaticTools.Next(StealMin, StealMax + 1);
+            var pointType = await pointsSystem.GetPointTypeForGame(ModuleName);
             if (targetPasties.Points < StealMax)
             {
                 await ServiceBackbone.ResponseWithMessage(e,
-                string.Format("{0} is to poor for you to steal from them, instead you give them {1} pasties.", targetDisplayName, amount.ToString("N0")));
+                string.Format("{0} is too poor for you to steal from them, instead you give them {1} {2}.", targetDisplayName, amount.ToString("N0"), pointType.Name));
                 await MovePoints(e.Name, e.TargetUser, amount);
 
                 // Trigger default command event for too poor
@@ -81,8 +84,8 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
             var rand = StaticTools.Next(1, 12 + 1);
             if (rand <= 4) // success
             {
-                await ServiceBackbone.SendChatMessage(string.Format("{0} successfully stole {1} pasties from {2}",
-                e.DisplayName, amount, targetDisplayName));
+                await ServiceBackbone.SendChatMessage(string.Format("{0} successfully stole {1} {2} from {3}",
+                e.DisplayName, amount, pointType.Name, targetDisplayName));
 
                 await MovePoints(e.TargetUser, e.Name, amount);
 
@@ -100,8 +103,8 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
             }
             else
             {
-                await ServiceBackbone.SendChatMessage(string.Format("{0} failed to steal {1} pasties from {2}, {2} gets {1} pasties from {0} instead",
-               e.DisplayName, amount, targetDisplayName));
+                await ServiceBackbone.SendChatMessage(string.Format("{0} failed to steal {1} {2} from {3}, {3} gets {1} {2} from {0} instead",
+               e.DisplayName, amount, pointType.Name, targetDisplayName));
                 await MovePoints(e.Name, e.TargetUser, amount);
 
                 // Trigger default command event for failed

--- a/PenguinTwitchBot/Bot/Commands/PastyGames/Tax.cs
+++ b/PenguinTwitchBot/Bot/Commands/PastyGames/Tax.cs
@@ -67,6 +67,7 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
                     return;
                 }
                 long totalRemoved = 0;
+                var pointType = await _pointSystem.GetPointTypeForGame(ModuleName);
                 foreach (var viewer in viewers)
                 {
                     //await using var scope = _scopeFactory.CreateAsyncScope();
@@ -83,7 +84,7 @@ namespace PenguinTwitchBot.Bot.Commands.PastyGames
                     //db.ViewerPoints.Update(viewerPoints);
                     //await db.SaveChangesAsync();
                 }
-                _logger.LogInformation("Removed {totalRemoved} pasties via taxes", totalRemoved);
+                _logger.LogInformation("Removed {totalRemoved} {pointType} via taxes", totalRemoved, pointType.Name);
             }
             catch (Exception ex)
             {

--- a/PenguinTwitchBot/Bot/Core/DiscordService.cs
+++ b/PenguinTwitchBot/Bot/Core/DiscordService.cs
@@ -112,12 +112,13 @@ namespace PenguinTwitchBot.Bot.Core
 
                 var channel = (IMessageChannel)await guild.GetChannelAsync(_settings.BroadcastChannel);
                 var imageUrl = await _twitchService.GetStreamThumbnail();
+                var profileImageUrl = await _twitchService.GetBroadcasterProfileImageUrl();
 
                 imageUrl = imageUrl.Replace("{width}", "400").Replace("{height}", "225");
                 _logger.LogInformation("Thumbnail Url: {imageUrl}", imageUrl);
                 var embed = new EmbedBuilder()
                     .WithColor(100, 65, 164)
-                    .WithThumbnailUrl("https://static-cdn.jtvnw.net/jtv_user_pictures/7397d16d-a2ff-4835-8f63-249b4738581b-profile_image-300x300.png")
+                    .WithThumbnailUrl(profileImageUrl ?? string.Empty)
                     .WithTitle($"{_broadcaster} has just went live on Twitch!")
                     .AddField("Now Playing", await _twitchService.GetCurrentGame())
                     .AddField("Stream Title", await _twitchService.GetStreamTitle())

--- a/PenguinTwitchBot/Bot/Models/LeaderboardsLayoutConfig.cs
+++ b/PenguinTwitchBot/Bot/Models/LeaderboardsLayoutConfig.cs
@@ -88,14 +88,13 @@ public static class LeaderboardsWidgetCatalog
         };
     }
 
-    public static LeaderboardsLayoutConfig CreateDefaultLayout(int? ticketPointTypeId = null, int? pastiesPointTypeId = 1)
+    public static LeaderboardsLayoutConfig CreateDefaultLayout(int? defaultPointTypeId = null)
     {
         return new LeaderboardsLayoutConfig
         {
             Widgets =
             [
-                CreateDefaultWidget(PointLeaderboard, ticketPointTypeId, "Tickets"),
-                CreateDefaultWidget(PointLeaderboard, pastiesPointTypeId, "Pasties"),
+                CreateDefaultWidget(PointLeaderboard, defaultPointTypeId),
                 CreateDefaultWidget(Loudest),
                 CreateDefaultWidget(WatchedTime),
             ]

--- a/PenguinTwitchBot/Bot/TwitchServices/ITwitchService.cs
+++ b/PenguinTwitchBot/Bot/TwitchServices/ITwitchService.cs
@@ -64,5 +64,6 @@ namespace PenguinTwitchBot.Bot.TwitchServices
         /// Combines global and channel-specific badges; channel badges override globals.
         /// </summary>
         Task<Dictionary<string, string>> GetChatBadgesAsync();
+        Task<string?> GetBroadcasterProfileImageUrl();
     }
 }

--- a/PenguinTwitchBot/Bot/TwitchServices/TwitchService.cs
+++ b/PenguinTwitchBot/Bot/TwitchServices/TwitchService.cs
@@ -464,6 +464,14 @@ namespace PenguinTwitchBot.Bot.TwitchServices
             return broadcasterId;
         }
 
+        public async Task<string?> GetBroadcasterProfileImageUrl()
+        {
+            var broadcaster = _configuration["broadcaster"];
+            if (string.IsNullOrWhiteSpace(broadcaster)) return null;
+            var user = await GetUserByName(broadcaster);
+            return user?.ProfileImageUrl;
+        }
+
         public async Task<string?> GetBotUserId()
         {
             var bot = _configuration["botName"];

--- a/PenguinTwitchBot/Pages/Commands/CommandCooldowns.razor
+++ b/PenguinTwitchBot/Pages/Commands/CommandCooldowns.razor
@@ -20,9 +20,9 @@
                         context.UserName)
                 </MudTd>
                 <MudTd DataLabel="Cooldown">
-                    @(context.NextUserCooldownTime == DateTime.MinValue ?
+                    <ToLocal DateTime="context.NextUserCooldownTime == DateTime.MinValue ?
                         context.NextGlobalCooldownTime :
-                        context.NextUserCooldownTime)
+                        context.NextUserCooldownTime" Format="dddd, mmmm d h:MM:ss TT"></ToLocal>
                 </MudTd>
                 <MudTd DataLabel="Edit">
                     <MudButton Variant="Variant.Filled" Color="Color.Primary" 

--- a/PenguinTwitchBot/Pages/Components/LeaderboardsLayout.razor
+++ b/PenguinTwitchBot/Pages/Components/LeaderboardsLayout.razor
@@ -134,16 +134,12 @@ else
     private bool isEditing;
     private string selectedWidgetType = LeaderboardsWidgetCatalog.PointLeaderboard;
     private IReadOnlyList<PointType> PointTypes { get; set; } = [];
-    private int? defaultTicketsPointTypeId;
-    private int? defaultPastiesPointTypeId = 1;
-
     protected override async Task OnInitializedAsync()
     {
         var authState = await AuthenticationStateProvider.GetAuthenticationStateAsync();
         isStreamer = authState.User.IsInRole("Streamer");
 
         PointTypes = (await PointsSystem.GetPointTypes()).ToList();
-        defaultTicketsPointTypeId = (await PointsSystem.GetPointTypeForGame("giveawayfeature")).GetId();
 
         await ReloadSavedLayoutAsync();
         isLoaded = true;
@@ -152,7 +148,7 @@ else
     private async Task ReloadSavedLayoutAsync()
     {
         var savedLayout = await LeaderboardsLayoutService.GetLayoutAsync();
-        layout = savedLayout ?? LeaderboardsWidgetCatalog.CreateDefaultLayout(defaultTicketsPointTypeId, defaultPastiesPointTypeId);
+        layout = savedLayout ?? LeaderboardsWidgetCatalog.CreateDefaultLayout(PointTypes.FirstOrDefault()?.Id);
         layout = LeaderboardsWidgetCatalog.Normalize(layout);
         editableWidgets.Clear();
         editableWidgets.AddRange(layout.Widgets.Select(LeaderboardsWidgetCatalog.Normalize));
@@ -206,7 +202,7 @@ else
         try
         {
             await LeaderboardsLayoutService.ResetLayoutAsync();
-            layout = LeaderboardsWidgetCatalog.CreateDefaultLayout(defaultTicketsPointTypeId, defaultPastiesPointTypeId);
+            layout = LeaderboardsWidgetCatalog.CreateDefaultLayout(PointTypes.FirstOrDefault()?.Id);
             layout = LeaderboardsWidgetCatalog.Normalize(layout);
             ReloadWorkingLayout();
             Snackbar.Add("Leaderboards layout reset to the default.", Severity.Success);
@@ -236,7 +232,7 @@ else
     {
         editableWidgets.Add(LeaderboardsWidgetCatalog.Normalize(LeaderboardsWidgetCatalog.CreateDefaultWidget(
             selectedWidgetType,
-            defaultTicketsPointTypeId,
+            PointTypes.FirstOrDefault()?.Id,
             selectedWidgetType == LeaderboardsWidgetCatalog.PointLeaderboard ? "" : null)));
     }
 

--- a/PenguinTwitchBot/Pages/Fishing/FishingHelp.razor
+++ b/PenguinTwitchBot/Pages/Fishing/FishingHelp.razor
@@ -51,12 +51,6 @@
                                 <strong>Pro Tip:</strong> Visit the Shop and Inventory pages on the website to manage your equipment and see detailed statistics!
                             </MudText>
                         </MudAlert>
-                        <MudAlert Severity="Severity.Success" Dense="false">
-                            <MudText Typo="Typo.body2">
-                                <MudIcon Icon="@Icons.Material.Filled.TipsAndUpdates" Size="Size.Small" />
-                                <strong>Hint:</strong> Every fish caught earns pasties! The higher gold, rare, and quality of fish you catch, the more pasties you earn! (Gold is only for fishing)
-                            </MudText>
-                        </MudAlert>
                     </MudStack>
                 </MudItem>
             </MudGrid>

--- a/PenguinTwitchBot/Pages/Moderator/EditViewer.razor
+++ b/PenguinTwitchBot/Pages/Moderator/EditViewer.razor
@@ -39,8 +39,10 @@ else
                             <MudTextField @bind-Value="viewer.DateCreated" Label="Account Created" ReadOnly="true" Variant="Variant.Text" />
                             <MudTextField @bind-Value="viewer.LastSub" Label="Last Sub" ReadOnly="true" Variant="Variant.Text" />
                             <MudText>Messages Rank: #@viewer.Messages?.Ranking Total: @viewer.Messages?.MessageCount</MudText>
-                            <MudText>Pasties Rank: #@viewer.Pasties?.Ranking Total: @viewer.Pasties?.Points</MudText>
-                            <MudText>Tickets Rank: #@viewer.Tickets?.Ranking Total: @viewer.Tickets?.Points</MudText>
+                            @foreach (var pr in viewer.PointRankings)
+                            {
+                                <MudText>@pr.PointTypeName Rank: #@pr.Ranking?.Ranking Total: @pr.Ranking?.Points</MudText>
+                            }
                             <MudText>Watch Time Rank: #@viewer.Time?.Ranking Total: @viewer.WatchedTime</MudText>
 
                             <MudButton ButtonType="ButtonType.Submit" Variant="Variant.Filled" Color="Color.Primary" Class="ml-auto">
@@ -152,6 +154,12 @@ else
     private string username { get; set; } = "";
     private bool includeCommands { get; set; } = false;
 
+    public class ViewerPointRanking
+    {
+        public string PointTypeName { get; set; } = "";
+        public UserPointsWithRank? Ranking { get; set; }
+    }
+
     private EventCallback<bool> CommandsViewChanged { get; set; }
     public class ViewViewer
     {
@@ -160,8 +168,7 @@ else
         public DateTime? LastSub { get; set; }
         public DateTime? DateCreated { get; set; }
         public ViewerMessageCountWithRank? Messages { get; set; }
-        public UserPointsWithRank? Pasties { get; set; }
-        public UserPointsWithRank? Tickets { get; set; }
+        public List<ViewerPointRanking> PointRankings { get; set; } = [];
         public ViewerTimeWithRank? Time { get; set; }
         public string WatchedTime { get; set; } = "";
 
@@ -185,9 +192,13 @@ else
             {
                 viewer.FollowDated = follower.FollowDate;
             }
-            var giveawayPointsSystem = await pointSystem.GetPointTypeForGame("giveawayfeature");
-            viewer.Tickets = await pointSystem.GetPointsWithRankByUserId(viewer.Viewer.UserId, giveawayPointsSystem.Id.GetValueOrDefault());
-            viewer.Pasties = await pointSystem.GetPointsWithRankByUserId(viewer.Viewer.UserId, 1);
+            var allPointTypes = await pointSystem.GetPointTypes();
+            viewer.PointRankings = [];
+            foreach (var pt in allPointTypes)
+            {
+                var rank = await pointSystem.GetPointsWithRankByUserId(viewer.Viewer.UserId, pt.Id.GetValueOrDefault());
+                viewer.PointRankings.Add(new ViewerPointRanking { PointTypeName = pt.Name, Ranking = rank });
+            }
             viewer.Messages = await loyaltyFeature.GetUserMessagesAndRank(viewer.Viewer.Username);
             viewer.Time = await loyaltyFeature.GetUserTimeAndRank(viewer.Viewer.Username);
             viewer.DateCreated = await viewerFeature.GetUserCreatedAsync(viewer.Viewer.Username);

--- a/PenguinTwitchBot/Pages/PointGameSettings/Providers/HeistSettingsProvider.cs
+++ b/PenguinTwitchBot/Pages/PointGameSettings/Providers/HeistSettingsProvider.cs
@@ -22,7 +22,7 @@ public class HeistSettingsProvider : IGameSettingsFormProvider
             [Heist.JOINTIME]        = await svc.GetIntSetting(Heist.GAMENAME, Heist.JOINTIME, 300),
             [Heist.MINBET]          = await svc.GetIntSetting(Heist.GAMENAME, Heist.MINBET, 100),
             [Heist.WIN_MULTIPLIER]  = await svc.GetDoubleSetting(Heist.GAMENAME, Heist.WIN_MULTIPLIER, 1.5),
-            [Heist.STAGEONE]        = await svc.GetStringSetting(Heist.GAMENAME, Heist.STAGEONE, "The crew gets ready to steal some pasties!"),
+            [Heist.STAGEONE]        = await svc.GetStringSetting(Heist.GAMENAME, Heist.STAGEONE, "The crew gets ready to steal some points!"),
             [Heist.STAGETWO]        = await svc.GetStringSetting(Heist.GAMENAME, Heist.STAGETWO, "Everyone sharpens their beaks and sneaks in!"),
             [Heist.STAGETHREE]      = await svc.GetStringSetting(Heist.GAMENAME, Heist.STAGETHREE, "Look out! {Caught} got caught!"),
             [Heist.STAGEFOUR]       = await svc.GetStringSetting(Heist.GAMENAME, Heist.STAGEFOUR, "{Survivors} managed to escape with the loot!"),

--- a/PenguinTwitchBot/Shared/MainLayout.razor
+++ b/PenguinTwitchBot/Shared/MainLayout.razor
@@ -35,7 +35,7 @@
         <MudAppBar>
             <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start"
             OnClick="@((e) => DrawerToggle())" />
-            Super Waffle Bot
+            @(AppConfiguration["ApplicationTitle"] ?? "Penguin Twitch Bot")
             <MudSpacer />
             @if(StreamOnline)
             {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Games now display dynamic point type names instead of fixed labels.
  * Discord announcements now feature the broadcaster's profile image.
  * Cooldown times display in localized date/time format.
  * Viewer rankings now show all configured point types dynamically.
  * App title is now configurable.
  * Updated fishing help content with new guidance.
  * Leaderboard defaults now based on available point types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->