### PR TITLE
Fixes point usernames when they update

### DIFF
--- a/PenguinTwitchBot.Test/Bot/Core/Points/PointsSystemTests.cs
+++ b/PenguinTwitchBot.Test/Bot/Core/Points/PointsSystemTests.cs
@@ -460,11 +460,11 @@ namespace PenguinTwitchBot.Test.Bot.Core.Points
             var gameName = "game1";
             var points = 100;
             var pointType = new PointType { Id = 1 };
-            var viewer = new Viewer { UserId = "user1" };
-            var userPoints = new UserPoints { UserId = viewer.UserId, PointTypeId = (int)pointType.Id, Points = 100 };
+            var viewer = new Viewer { UserId = "user1", Username = "TestUser" };
+            var userPoints = new UserPoints { UserId = viewer.UserId, Username = viewer.Username, PointTypeId = (int)pointType.Id, Points = 100 };
 
             _gameSettingsServiceMock.GetPointTypeForGame(gameName).Returns(pointType);
-            _viewerFeatureMock.GetViewerByUserId(userId).Returns(new Viewer { UserId = userId });
+            _viewerFeatureMock.GetViewerByUserId(userId).Returns(viewer);
             _unitOfWorkMock.UserPoints.GetUserPointsByUserId(viewer.UserId, (int)pointType.Id).Returns(userPoints);
 
             // Act
@@ -483,13 +483,13 @@ namespace PenguinTwitchBot.Test.Bot.Core.Points
             var gameName = "game1";
             var points = 100;
             var pointType = new PointType { Id = 1 };
-            var viewer = new Viewer { UserId = "user1" };
+            var viewer = new Viewer { UserId = "user1", Username = username };
             var userId = "user1";
-            var userPoints = new UserPoints { UserId = viewer.UserId, PointTypeId = (int)pointType.Id, Points = 100 };
+            var userPoints = new UserPoints { UserId = viewer.UserId, Username = viewer.Username, PointTypeId = (int)pointType.Id, Points = 100 };
 
             _viewerFeatureMock.GetViewerByUserName(username).Returns(viewer);
             _gameSettingsServiceMock.GetPointTypeForGame(gameName).Returns(pointType);
-            _viewerFeatureMock.GetViewerByUserId(userId).Returns(new Viewer { UserId = userId });
+            _viewerFeatureMock.GetViewerByUserId(userId).Returns(viewer);
             _unitOfWorkMock.UserPoints.GetUserPointsByUserId(viewer.UserId, (int)pointType.Id).Returns(userPoints);
 
             // Act

--- a/PenguinTwitchBot/Bot/Core/Points/PointsSystem.cs
+++ b/PenguinTwitchBot/Bot/Core/Points/PointsSystem.cs
@@ -52,6 +52,10 @@ namespace PenguinTwitchBot.Bot.Core.Points
                 }
                 else
                 {
+                    if(!userPoints.Username.Equals(viewer.Username, StringComparison.OrdinalIgnoreCase))
+                    {
+                        userPoints.Username = viewer.Username;
+                    }
                     userPoints.Points += points;
                     db.UserPoints.Update(userPoints);
                 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed username synchronization in points tracking to display the most current viewer display name, ensuring consistency across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->