### PR TITLE
Update so multiple playlists can be enabled at same time

### DIFF
--- a/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
+++ b/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
@@ -32,6 +32,7 @@ namespace PenguinTwitchBot.Bot.Commands.Music
         private readonly TimeLeft timeLeft = new();
 
         private static readonly string LastSongList = "LastSongList";
+        private const string AdditionalPlaylistsSetting = "AdditionalPlaylists";
         enum PlayerState
         {
             UnStarted = -1,
@@ -162,24 +163,19 @@ namespace PenguinTwitchBot.Bot.Commands.Music
 
         private async Task LoadBackupList()
         {
+            var defaultPlaylistId = BackupPlaylist?.Id;
+            var additionalIds = await GetAdditionalPlaylistIds();
+            var selectedPlaylistIds = new HashSet<int>();
+            if (defaultPlaylistId.HasValue)
+                selectedPlaylistIds.Add(defaultPlaylistId.Value);
+            foreach (var id in additionalIds)
+                selectedPlaylistIds.Add(id);
 
-            await using (var scope = _scopeFactory.CreateAsyncScope())
+            if (selectedPlaylistIds.Count == 0)
             {
-                var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-                var lastPlaylist = await db.Settings.Find(x => x.Name.Equals(LastSongList)).FirstOrDefaultAsync();
-                if (lastPlaylist != null)
+                await using (var scope = _scopeFactory.CreateAsyncScope())
                 {
-                    var playList = (await db.Playlists.GetAsync(filter: x => x.Id == lastPlaylist.IntSetting, includeProperties: "Songs")).FirstOrDefault();
-                    if (playList != null && playList.Songs != null && playList.Songs.Count > 0)
-                    {
-                        BackupPlaylist = playList;
-                        await UpdateRequestedSongsState();
-                        await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);
-                        UpdateUnplayedSongs();
-                        return;
-                    }
-                }
-                {
+                    var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
                     var playList = (await db.Playlists.GetAsync(orderBy: x => x.OrderBy(y => y.Id), includeProperties: "Songs")).FirstOrDefault();
                     if (playList != null && playList.Songs != null && playList.Songs.Count > 0)
                     {
@@ -191,13 +187,41 @@ namespace PenguinTwitchBot.Bot.Commands.Music
                     }
                 }
             }
+            else
+            {
+                await using (var scope = _scopeFactory.CreateAsyncScope())
+                {
+                    var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+                    var allSongs = new Dictionary<string, Song>();
+                    foreach (var playlistId in selectedPlaylistIds)
+                    {
+                        var playList = (await db.Playlists.GetAsync(filter: x => x.Id == playlistId, includeProperties: "Songs")).FirstOrDefault();
+                        if (playList != null && playList.Songs != null)
+                        {
+                            foreach (var s in playList.Songs)
+                            {
+                                if (!allSongs.ContainsKey(s.SongId))
+                                    allSongs.Add(s.SongId, s);
+                            }
+                        }
+                    }
+                    if (allSongs.Count > 0)
+                    {
+                        BackupPlaylist = new MusicPlaylist { Name = "Multi Playlist", Songs = [.. allSongs.Values] };
+                        await UpdateRequestedSongsState();
+                        await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);
+                        UpdateUnplayedSongs();
+                        return;
+                    }
+                }
+            }
 
             var song = await GetSong("ZyhrYis509A");
             if (song != null)
-                BackupPlaylist.Songs.Add(song);
+                BackupPlaylist?.Songs.Add(song);
             song = await GetSong("EAwWPadFsOA");
             if (song != null)
-                BackupPlaylist.Songs.Add(song);
+                BackupPlaylist?.Songs.Add(song);
             UpdateUnplayedSongs();
         }
 
@@ -213,7 +237,7 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             SongsInBackupQueueMetric.IncTo(UnplayedSongs.Count);
         }
 
-        public async void UpdateState(int state)
+        public async Task UpdateState(int state)
         {
             this.State = (PlayerState)state;
             _logger.LogDebug("Player State {this.State}", state);
@@ -303,6 +327,95 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             return [.. await db.Playlists.GetAllAsync()];
         }
 
+        public async Task SetPlaylists(int? defaultPlaylistId, List<int> additionalPlaylistIds)
+        {
+            await using (var scope = _scopeFactory.CreateAsyncScope())
+            {
+                var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+                var playList = (await db.Playlists.GetAsync(filter: x => x.Id == defaultPlaylistId, includeProperties: "Songs")).FirstOrDefault();
+                if (playList != null)
+                {
+                    BackupPlaylist = playList;
+                    var lastPlaylist = await db.Settings.Find(x => x.Name.Equals(LastSongList)).FirstOrDefaultAsync();
+                    lastPlaylist ??= new Setting { Name = LastSongList };
+                    lastPlaylist.IntSetting = playList.Id ?? default;
+                    db.Settings.Update(lastPlaylist);
+
+                    var additionalSetting = await db.Settings.Find(x => x.Name.Equals(AdditionalPlaylistsSetting)).FirstOrDefaultAsync();
+                    additionalSetting ??= new Setting { Name = AdditionalPlaylistsSetting, DataType = Setting.DataTypeEnum.String };
+                    additionalSetting.StringSetting = string.Join(",", additionalPlaylistIds.Distinct().Where(id => id != defaultPlaylistId));
+                    db.Settings.Update(additionalSetting);
+
+                    await db.SaveChangesAsync();
+                }
+            }
+
+            if (additionalPlaylistIds != null && additionalPlaylistIds.Count > 0)
+            {
+                BackupPlaylist.Name = "Multi Playlist";
+                await MergeAdditionalPlaylistsAsync(additionalPlaylistIds);
+            }
+
+            UpdateUnplayedSongs();
+            await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);
+            await UpdateRequestedSongsState();
+        }
+
+        private async Task MergeAdditionalPlaylistsAsync(List<int> additionalPlaylistIds)
+        {
+            if (additionalPlaylistIds == null || additionalPlaylistIds.Count == 0) return;
+
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var allSongs = new Dictionary<string, Song>();
+            if (BackupPlaylist != null && BackupPlaylist.Songs != null)
+            {
+                foreach (var s in BackupPlaylist.Songs)
+                {
+                    if (!allSongs.ContainsKey(s.SongId))
+                        allSongs.Add(s.SongId, s);
+                }
+            }
+            foreach (var playlistId in additionalPlaylistIds.Distinct())
+            {
+                var playList = (await db.Playlists.GetAsync(filter: x => x.Id == playlistId, includeProperties: "Songs")).FirstOrDefault();
+                if (playList != null && playList.Songs != null)
+                {
+                    foreach (var s in playList.Songs)
+                    {
+                        if (!allSongs.ContainsKey(s.SongId))
+                            allSongs.Add(s.SongId, s);
+                    }
+                }
+            }
+            if (BackupPlaylist == null)
+                BackupPlaylist = new MusicPlaylist();
+            BackupPlaylist.Songs = [.. allSongs.Values];
+        }
+
+        public async Task RefreshUnplayedSongs()
+        {
+            var additionalIds = await GetAdditionalPlaylistIds();
+            if (additionalIds != null && additionalIds.Count > 0)
+            {
+                BackupPlaylist.Name = "Multi Playlist";
+                await MergeAdditionalPlaylistsAsync(additionalIds);
+            }
+            UpdateUnplayedSongs();
+            await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);
+        }
+
+        public async Task<List<int>> GetAdditionalPlaylistIds()
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var setting = await db.Settings.Find(x => x.Name.Equals(AdditionalPlaylistsSetting)).FirstOrDefaultAsync();
+            if (setting == null || string.IsNullOrEmpty(setting.StringSetting))
+                return new List<int>();
+            return setting.StringSetting.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Select(s => int.Parse(s)).ToList();
+        }
+
         public async Task<MusicPlaylist> GetPlayList(int id)
         {
             await using var scope = _scopeFactory.CreateAsyncScope();
@@ -317,6 +430,15 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             var playList = (await db.Playlists.GetAsync(x => x.Id == id, includeProperties: "Songs")).FirstOrDefault();
             if (playList == null) return;
             db.Playlists.Remove(playList);
+            await db.SaveChangesAsync();
+        }
+
+        public async Task CreatePlaylist(string name)
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var playList = new MusicPlaylist { Name = name };
+            db.Playlists.Add(playList);
             await db.SaveChangesAsync();
         }
 

--- a/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
+++ b/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
@@ -163,10 +163,10 @@ namespace PenguinTwitchBot.Bot.Commands.Music
 
         private async Task LoadBackupList()
         {
-            var defaultPlaylistId = BackupPlaylist?.Id;
+            var defaultPlaylistId = BackupPlaylist?.Id ?? await GetDefaultPlaylistId();
             var additionalIds = await GetAdditionalPlaylistIds();
             var selectedPlaylistIds = new HashSet<int>();
-            if (defaultPlaylistId.HasValue)
+            if (defaultPlaylistId.HasValue && defaultPlaylistId.Value > 0)
                 selectedPlaylistIds.Add(defaultPlaylistId.Value);
             foreach (var id in additionalIds)
                 selectedPlaylistIds.Add(id);
@@ -576,6 +576,24 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             }
         }
 
+        public async Task RemoveSongFromPlaylist(Song requestedSong, int playlistId)
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var playList = (await db.Playlists.GetAsync(filter: x => x.Id == playlistId, includeProperties: "Songs")).FirstOrDefault();
+            if (playList == null || playList.Songs == null) return;
+            var song = playList.Songs.Where(x => x.SongId.Equals(requestedSong.SongId)).FirstOrDefault();
+            if (song == null) return;
+            playList.Songs.Remove(song);
+            db.Songs.Remove(song);
+            await db.SaveChangesAsync();
+            if (BackupPlaylist.Songs.Contains(requestedSong))
+            {
+                BackupPlaylist.Songs.Remove(requestedSong);
+            }
+            await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);
+        }
+
         public async Task RemoveSong(Song requestedSong)
         {
             if (BackupPlaylist.Songs.Count == 0) return;
@@ -586,12 +604,10 @@ namespace PenguinTwitchBot.Bot.Commands.Music
                 return;
             }
 
-
             await using (var scope = _scopeFactory.CreateAsyncScope())
             {
                 var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
                 BackupPlaylist.Songs.Remove(song);
-                db.Playlists.Update(BackupPlaylist);
                 db.Songs.Remove(song);
                 await db.SaveChangesAsync();
             }
@@ -616,11 +632,12 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             var songToSteel = CurrentSong.CreateDeepCopy();
             songToSteel.Id = null;
             songToSteel.RequestedBy = ServiceBackbone.BotName ?? "TheBot";
+            songToSteel.MusicPlaylistId = BackupPlaylist.Id ?? default;
             BackupPlaylist.Songs.Add(songToSteel);
             await using (var scope = _scopeFactory.CreateAsyncScope())
             {
                 var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
-                db.Playlists.Update(BackupPlaylist);
+                db.Songs.Add(songToSteel);
                 await db.SaveChangesAsync();
             }
             await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);

--- a/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
+++ b/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
@@ -405,6 +405,25 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);
         }
 
+        public async Task<Dictionary<int, string>> GetPlaylistsContainingSong(string songId, List<int> playlistIds)
+        {
+            var result = new Dictionary<int, string>();
+            if (string.IsNullOrEmpty(songId) || playlistIds == null || playlistIds.Count == 0)
+                return result;
+
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            foreach (var playlistId in playlistIds.Distinct())
+            {
+                var playList = (await db.Playlists.GetAsync(filter: x => x.Id == playlistId, includeProperties: "Songs")).FirstOrDefault();
+                if (playList != null && playList.Songs != null && playList.Songs.Any(s => s.SongId.Equals(songId)))
+                {
+                    result[playlistId] = playList.Name;
+                }
+            }
+            return result;
+        }
+
         public async Task<List<int>> GetAdditionalPlaylistIds()
         {
             await using var scope = _scopeFactory.CreateAsyncScope();

--- a/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
+++ b/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
@@ -207,7 +207,7 @@ namespace PenguinTwitchBot.Bot.Commands.Music
                     }
                     if (allSongs.Count > 0)
                     {
-                        BackupPlaylist = new MusicPlaylist { Name = "Multi Playlist", Songs = [.. allSongs.Values] };
+                        BackupPlaylist = new MusicPlaylist { Id = defaultPlaylistId, Name = "Multi Playlist", Songs = [.. allSongs.Values] };
                         await UpdateRequestedSongsState();
                         await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);
                         UpdateUnplayedSongs();
@@ -414,6 +414,14 @@ namespace PenguinTwitchBot.Bot.Commands.Music
                 return new List<int>();
             return setting.StringSetting.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
                 .Select(s => int.Parse(s)).ToList();
+        }
+
+        public async Task<int?> GetDefaultPlaylistId()
+        {
+            await using var scope = _scopeFactory.CreateAsyncScope();
+            var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var setting = await db.Settings.Find(x => x.Name.Equals(LastSongList)).FirstOrDefaultAsync();
+            return setting?.IntSetting;
         }
 
         public async Task<MusicPlaylist> GetPlayList(int id)

--- a/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
+++ b/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
@@ -600,15 +600,19 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             await using var scope = _scopeFactory.CreateAsyncScope();
             var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
             var playList = (await db.Playlists.GetAsync(filter: x => x.Id == playlistId, includeProperties: "Songs")).FirstOrDefault();
+           
             if (playList == null || playList.Songs == null) return;
+
             var song = playList.Songs.Where(x => x.SongId.Equals(requestedSong.SongId)).FirstOrDefault();
             if (song == null) return;
+            
             playList.Songs.Remove(song);
             db.Songs.Remove(song);
             await db.SaveChangesAsync();
-            if (BackupPlaylist.Songs.Contains(requestedSong))
+            if (BackupPlaylist.Songs.Any(x => x.SongId.Equals(requestedSong.SongId)))
             {
-                BackupPlaylist.Songs.Remove(requestedSong);
+                var inMemorySong = BackupPlaylist.Songs.First(x => x.SongId.Equals(requestedSong.SongId));
+                BackupPlaylist.Songs.Remove(inMemorySong);
             }
             await _hubContext.Clients.All.SendAsync("UpdateCurrentPlaylist", BackupPlaylist);
         }
@@ -643,6 +647,7 @@ namespace PenguinTwitchBot.Bot.Commands.Music
         {
             if (BackupPlaylist.Songs.Count == 0) return;
             if (CurrentSong == null) return;
+            if (!BackupPlaylist.Id.HasValue || BackupPlaylist.Id.Value <= 0) return;
             if (BackupPlaylist.Songs.Where(x => x.SongId.Equals(CurrentSong.SongId)).Any())
             {
                 await ServiceBackbone.SendChatMessage("Song is already in the list.");
@@ -651,7 +656,7 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             var songToSteel = CurrentSong.CreateDeepCopy();
             songToSteel.Id = null;
             songToSteel.RequestedBy = ServiceBackbone.BotName ?? "TheBot";
-            songToSteel.MusicPlaylistId = BackupPlaylist.Id ?? default;
+            songToSteel.MusicPlaylistId = BackupPlaylist.Id.Value;
             BackupPlaylist.Songs.Add(songToSteel);
             await using (var scope = _scopeFactory.CreateAsyncScope())
             {

--- a/PenguinTwitchBot/Bot/Hubs/YtHub.cs
+++ b/PenguinTwitchBot/Bot/Hubs/YtHub.cs
@@ -25,9 +25,9 @@ namespace PenguinTwitchBot.Bot.Commands.Music
         }
 
         [Authorize(Roles = "Streamer")]
-        public void UpdateState(int state)
+        public async Task UpdateState(int state)
         {
-            _ytPlayer.UpdateState(state);
+            await _ytPlayer.UpdateState(state);
         }
 
         [Authorize(Roles = "Streamer")]

--- a/PenguinTwitchBot/Pages/Components/AvailablePlaylists.razor
+++ b/PenguinTwitchBot/Pages/Components/AvailablePlaylists.razor
@@ -1,0 +1,99 @@
+@using MudBlazor
+@using PenguinTwitchBot.Bot.Models
+
+<MudPaper Elevation="3">
+    <MudTable Items="@Playlists" Dense="true" Hover="true">
+        <ToolBarContent>
+            <MudIcon Icon="@Icons.Material.Filled.LibraryMusic" Color="Color.Secondary" Class="mr-2" />
+            <MudText Typo="Typo.h6">Available Playlists</MudText>
+            <MudSpacer />
+            @if (ToolBarContent is not null)
+            {
+                @ToolBarContent
+            }
+            @if (OnRefresh.HasDelegate)
+            {
+                <MudTooltip Text="Refresh Unplayed Songs">
+                    <MudIconButton Icon="@Icons.Material.Filled.Refresh" Color="Color.Info" Size="Size.Small"
+                                   OnClick="() => OnRefresh.InvokeAsync()" Class="mr-2" />
+                </MudTooltip>
+            }
+            <MudBadge Content="@Playlists.Count" Color="Color.Info" Overlap="true">
+                <MudIcon Icon="@Icons.Material.Filled.PlaylistPlay" Color="Color.Default" />
+            </MudBadge>
+        </ToolBarContent>
+        <HeaderContent>
+            <MudTh>Playlist Name</MudTh>
+            <MudTh>Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Name">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@Icons.Material.Filled.PlaylistPlay" Size="Size.Small" Color="Color.Primary" />
+                    <MudText><strong>@context.Name</strong></MudText>
+                </MudStack>
+            </MudTd>
+            <MudTd DataLabel="Actions">
+                <MudStack Row="true" Spacing="1">
+                    @if (OnSetDefault.HasDelegate && DefaultPlaylistId != context.Id)
+                    {
+                        <MudTooltip Text="Set as Default">
+                            <MudIconButton Icon="@Icons.Material.Filled.Star" Color="Color.Warning" Size="Size.Small"
+                                           OnClick="() => OnSetDefault.InvokeAsync(context)" />
+                        </MudTooltip>
+                    }
+                    else if (OnSetDefault.HasDelegate && DefaultPlaylistId == context.Id)
+                    {
+                        <MudTooltip Text="Default Playlist">
+                            <MudIconButton Icon="@Icons.Material.Filled.Star" Color="Color.Warning" Size="Size.Small" Disabled="true" />
+                        </MudTooltip>
+                    }
+                    @if (OnToggleAdditional.HasDelegate && DefaultPlaylistId != context.Id)
+                    {
+                        var isChecked = AdditionalPlaylistIds.Contains(context.Id.Value);
+                        <MudTooltip Text="@(isChecked ? "Remove from Additional" : "Add to Additional")">
+                            <MudCheckBox T="bool" Value="isChecked" ValueChanged="(bool c) => OnToggleAdditional.InvokeAsync((context, c))" />
+                        </MudTooltip>
+                    }
+                    else if (DefaultPlaylistId == context.Id)
+                    {
+                        <MudTooltip Text="Default Playlist (included)">
+                            <MudIconButton Icon="@Icons.Material.Filled.Check" Color="Color.Success" Size="Size.Small" Disabled="true" />
+                        </MudTooltip>
+                    }
+                    @if (OnView.HasDelegate)
+                    {
+                        <MudTooltip Text="View">
+                            <MudIconButton Icon="@Icons.Material.Filled.Visibility" Color="Color.Primary" Size="Size.Small"
+                                           OnClick="() => OnView.InvokeAsync(context)" />
+                        </MudTooltip>
+                    }
+                    @if (OnDelete.HasDelegate)
+                    {
+                        <MudTooltip Text="Delete">
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
+                                           OnClick="() => OnDelete.InvokeAsync(context)" />
+                        </MudTooltip>
+                    }
+                </MudStack>
+            </MudTd>
+        </RowTemplate>
+        <NoRecordsContent>
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.PlaylistRemove">
+                No playlists available
+            </MudAlert>
+        </NoRecordsContent>
+    </MudTable>
+</MudPaper>
+
+@code {
+    [Parameter] public List<MusicPlaylist> Playlists { get; set; } = new();
+    [Parameter] public int? DefaultPlaylistId { get; set; }
+    [Parameter] public List<int> AdditionalPlaylistIds { get; set; } = new();
+    [Parameter] public EventCallback<MusicPlaylist> OnSetDefault { get; set; }
+    [Parameter] public EventCallback<(MusicPlaylist, bool)> OnToggleAdditional { get; set; }
+    [Parameter] public EventCallback<MusicPlaylist> OnView { get; set; }
+    [Parameter] public EventCallback<MusicPlaylist> OnDelete { get; set; }
+    [Parameter] public RenderFragment? ToolBarContent { get; set; }
+    [Parameter] public EventCallback OnRefresh { get; set; }
+}

--- a/PenguinTwitchBot/Pages/Components/CurrentPlaylist.razor
+++ b/PenguinTwitchBot/Pages/Components/CurrentPlaylist.razor
@@ -1,0 +1,83 @@
+@using MudBlazor
+@using PenguinTwitchBot.Bot.Models
+
+<MudPaper Elevation="3">
+    <MudTable Items="@AllSongs" Filter="new Func<Song,bool>(FilterSong)" Dense="true" Hover="true">
+        <ToolBarContent>
+            <MudIcon Icon="@Icons.Material.Filled.Album" Color="Color.Tertiary" Class="mr-2" />
+            <MudText Typo="Typo.h6">@Playlist?.Name</MudText>
+            <MudSpacer />
+            <MudTextField DebounceInterval="300" Variant="Variant.Outlined" Margin="Margin.Dense" @bind-Value="SearchString" Placeholder="Search songs" Adornment="Adornment.Start" AdornmentIcon="@Icons.Material.Filled.Search" IconSize="Size.Medium" Style="min-width: 200px;"></MudTextField>
+            <MudBadge Content="@(Playlist?.Songs.Count ?? 0)" Color="Color.Info" Overlap="true">
+                <MudIcon Icon="@Icons.Material.Filled.MusicNote" Color="Color.Default" />
+            </MudBadge>
+        </ToolBarContent>
+        <HeaderContent>
+            <MudTh>Title</MudTh>
+            <MudTh>Length</MudTh>
+            <MudTh>Actions</MudTh>
+        </HeaderContent>
+        <RowTemplate>
+            <MudTd DataLabel="Title">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
+                    <MudIcon Icon="@Icons.Material.Filled.MusicNote" Size="Size.Small" Color="Color.Secondary" />
+                    <MudText>@context.Title</MudText>
+                </MudStack>
+            </MudTd>
+            <MudTd DataLabel="Duration">@context.Duration</MudTd>
+            <MudTd DataLabel="Actions">
+                <MudStack Row="true" Spacing="1">
+                    @if (OnQueueSong.HasDelegate)
+                    {
+                        <MudTooltip Text="Add to Queue">
+                            <MudIconButton Icon="@Icons.Material.Filled.Queue" Color="Color.Primary" Size="Size.Small"
+                                           OnClick="() => OnQueueSong.InvokeAsync(context)" />
+                        </MudTooltip>
+                    }
+                    @if (OnRemoveSong.HasDelegate)
+                    {
+                        <MudTooltip Text="Remove from Playlist">
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
+                                           OnClick="() => OnRemoveSong.InvokeAsync(context)" />
+                        </MudTooltip>
+                    }
+                </MudStack>
+            </MudTd>
+        </RowTemplate>
+        <NoRecordsContent>
+            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.PlaylistRemove">
+                Playlist is empty
+            </MudAlert>
+        </NoRecordsContent>
+        <PagerContent>
+            <MudTablePager />
+        </PagerContent>
+    </MudTable>
+</MudPaper>
+
+@code {
+    [Parameter] public MusicPlaylist? Playlist { get; set; }
+    [Parameter] public EventCallback<Song> OnQueueSong { get; set; }
+    [Parameter] public EventCallback<Song> OnRemoveSong { get; set; }
+
+    private string _searchString = string.Empty;
+    private string SearchString
+    {
+        get => _searchString;
+        set
+        {
+            _searchString = value;
+            StateHasChanged();
+        }
+    }
+
+    private IEnumerable<Song> AllSongs => Playlist?.Songs ?? Enumerable.Empty<Song>();
+
+    private bool FilterSong(Song song)
+    {
+        if (string.IsNullOrWhiteSpace(SearchString))
+            return true;
+        var search = SearchString.Trim().ToLower();
+        return song.Title.Contains(search, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/PenguinTwitchBot/Pages/Components/CurrentPlaylist.razor
+++ b/PenguinTwitchBot/Pages/Components/CurrentPlaylist.razor
@@ -109,7 +109,7 @@
     private readonly DialogOptions _removeDialogOptions = new() { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
     private List<PlaylistCheckItem> _selectedPlaylists = new();
 
-    private async void OpenRemoveDialog(Song song)
+    private async Task OpenRemoveDialog(Song song)
     {
         _removingSong = song;
         if (OnGetPlaylistsForSong != null)

--- a/PenguinTwitchBot/Pages/Components/CurrentPlaylist.razor
+++ b/PenguinTwitchBot/Pages/Components/CurrentPlaylist.razor
@@ -1,5 +1,6 @@
 @using MudBlazor
 @using PenguinTwitchBot.Bot.Models
+@using System.Collections.Generic
 
 <MudPaper Elevation="3">
     <MudTable Items="@AllSongs" Filter="new Func<Song,bool>(FilterSong)" Dense="true" Hover="true">
@@ -32,13 +33,6 @@
                         <MudTooltip Text="Add to Queue">
                             <MudIconButton Icon="@Icons.Material.Filled.Queue" Color="Color.Primary" Size="Size.Small"
                                            OnClick="() => OnQueueSong.InvokeAsync(context)" />
-                        </MudTooltip>
-                    }
-                    @if (OnRemoveSong.HasDelegate && !OnRemoveSongFrom.HasDelegate)
-                    {
-                        <MudTooltip Text="Remove from Playlist">
-                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
-                                           OnClick="() => OnRemoveSong.InvokeAsync(context)" />
                         </MudTooltip>
                     }
                     @if (OnRemoveSongFrom.HasDelegate)
@@ -86,10 +80,8 @@
 @code {
     [Parameter] public MusicPlaylist? Playlist { get; set; }
     [Parameter] public EventCallback<Song> OnQueueSong { get; set; }
-    [Parameter] public EventCallback<Song> OnRemoveSong { get; set; }
     [Parameter] public EventCallback<(Song song, int playlistId)> OnRemoveSongFrom { get; set; }
-    [Parameter] public List<int> SelectedPlaylistIds { get; set; } = new();
-    [Parameter] public Dictionary<int, string> SelectedPlaylistNames { get; set; } = new();
+    [Parameter] public Func<Song, Task<Dictionary<int, string>>>? OnGetPlaylistsForSong { get; set; }
 
     private string _searchString = string.Empty;
     private string SearchString
@@ -117,13 +109,18 @@
     private readonly DialogOptions _removeDialogOptions = new() { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
     private List<PlaylistCheckItem> _selectedPlaylists = new();
 
-    private void OpenRemoveDialog(Song song)
+    private async void OpenRemoveDialog(Song song)
     {
         _removingSong = song;
-        _selectedPlaylists = SelectedPlaylistIds
-            .Where(id => SelectedPlaylistNames.ContainsKey(id))
-            .Select(id => new PlaylistCheckItem { Id = id, Name = SelectedPlaylistNames[id], IsChecked = false })
-            .ToList();
+        if (OnGetPlaylistsForSong != null)
+        {
+            var matched = await OnGetPlaylistsForSong(song);
+            _selectedPlaylists = matched.Select(kvp => new PlaylistCheckItem { Id = kvp.Key, Name = kvp.Value, IsChecked = false }).ToList();
+        }
+        else
+        {
+            _selectedPlaylists = _selectedPlaylists.ToList();
+        }
         _removeDialogVisible = true;
     }
 

--- a/PenguinTwitchBot/Pages/Components/CurrentPlaylist.razor
+++ b/PenguinTwitchBot/Pages/Components/CurrentPlaylist.razor
@@ -34,11 +34,18 @@
                                            OnClick="() => OnQueueSong.InvokeAsync(context)" />
                         </MudTooltip>
                     }
-                    @if (OnRemoveSong.HasDelegate)
+                    @if (OnRemoveSong.HasDelegate && !OnRemoveSongFrom.HasDelegate)
                     {
                         <MudTooltip Text="Remove from Playlist">
                             <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
                                            OnClick="() => OnRemoveSong.InvokeAsync(context)" />
+                        </MudTooltip>
+                    }
+                    @if (OnRemoveSongFrom.HasDelegate)
+                    {
+                        <MudTooltip Text="Remove from Playlist(s)">
+                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
+                                           OnClick="() => OpenRemoveDialog(context)" />
                         </MudTooltip>
                     }
                 </MudStack>
@@ -55,10 +62,34 @@
     </MudTable>
 </MudPaper>
 
+@if (OnRemoveSongFrom.HasDelegate)
+{
+    <MudDialog @bind-Visible="_removeDialogVisible" Options="_removeDialogOptions">
+        <DialogContent>
+            <MudText Typo="Typo.h6">Remove "@_removingSong?.Title" from:</MudText>
+            <MudStack Spacing="2" Class="mt-4">
+                @foreach (var pl in _selectedPlaylists)
+                {
+                    <MudCheckBox T="bool" Value="pl.IsChecked" ValueChanged="(bool c) => pl.IsChecked = c" Label="@pl.Name" />
+                }
+            </MudStack>
+        </DialogContent>
+        <DialogActions>
+            <MudButton Variant="Variant.Text" Color="Color.Default" OnClick="CloseRemoveDialog">Cancel</MudButton>
+            <MudButton Variant="Variant.Filled" Color="Color.Error" OnClick="ConfirmRemove" Disabled="@(!_selectedPlaylists.Any(p => p.IsChecked))">
+                Remove
+            </MudButton>
+        </DialogActions>
+    </MudDialog>
+}
+
 @code {
     [Parameter] public MusicPlaylist? Playlist { get; set; }
     [Parameter] public EventCallback<Song> OnQueueSong { get; set; }
     [Parameter] public EventCallback<Song> OnRemoveSong { get; set; }
+    [Parameter] public EventCallback<(Song song, int playlistId)> OnRemoveSongFrom { get; set; }
+    [Parameter] public List<int> SelectedPlaylistIds { get; set; } = new();
+    [Parameter] public Dictionary<int, string> SelectedPlaylistNames { get; set; } = new();
 
     private string _searchString = string.Empty;
     private string SearchString
@@ -79,5 +110,44 @@
             return true;
         var search = SearchString.Trim().ToLower();
         return song.Title.Contains(search, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private bool _removeDialogVisible;
+    private Song? _removingSong;
+    private readonly DialogOptions _removeDialogOptions = new() { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+    private List<PlaylistCheckItem> _selectedPlaylists = new();
+
+    private void OpenRemoveDialog(Song song)
+    {
+        _removingSong = song;
+        _selectedPlaylists = SelectedPlaylistIds
+            .Where(id => SelectedPlaylistNames.ContainsKey(id))
+            .Select(id => new PlaylistCheckItem { Id = id, Name = SelectedPlaylistNames[id], IsChecked = false })
+            .ToList();
+        _removeDialogVisible = true;
+    }
+
+    private void CloseRemoveDialog()
+    {
+        _removeDialogVisible = false;
+        _removingSong = null;
+        _selectedPlaylists.Clear();
+    }
+
+    private async Task ConfirmRemove()
+    {
+        if (_removingSong == null) return;
+        foreach (var pl in _selectedPlaylists.Where(p => p.IsChecked))
+        {
+            await OnRemoveSongFrom.InvokeAsync((_removingSong, pl.Id));
+        }
+        CloseRemoveDialog();
+    }
+
+    private class PlaylistCheckItem
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = "";
+        public bool IsChecked { get; set; }
     }
 }

--- a/PenguinTwitchBot/Pages/CreatePlaylistDialog.razor
+++ b/PenguinTwitchBot/Pages/CreatePlaylistDialog.razor
@@ -1,0 +1,34 @@
+@using MudBlazor
+
+<MudDialog>
+    <DialogContent>
+        <MudText Typo="Typo.h6">Create New Playlist</MudText>
+        <MudTextField @bind-Value="playlistName" Label="Playlist Name" Variant="Variant.Outlined" Required="true" RequiredError="Playlist name is required!" />
+    </DialogContent>
+    <DialogActions>
+        <MudButton Variant="Variant.Text" Color="Color.Default" OnClick="Cancel">Cancel</MudButton>
+        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="Submit" Disabled="string.IsNullOrWhiteSpace(playlistName)">Create</MudButton>
+    </DialogActions>
+</MudDialog>
+
+@code {
+    [CascadingParameter] private IMudDialogInstance MudDialog { get; set; } = null!;
+    [Parameter] public string? PlaylistName { get; set; }
+    private string playlistName = string.Empty;
+
+    protected override void OnInitialized()
+    {
+        if (!string.IsNullOrEmpty(PlaylistName))
+            playlistName = PlaylistName;
+    }
+
+    private void Submit()
+    {
+        MudDialog.Close(DialogResult.Ok(playlistName));
+    }
+
+    private void Cancel()
+    {
+        MudDialog.Cancel();
+    }
+}

--- a/PenguinTwitchBot/Pages/MusicPlayer.razor
+++ b/PenguinTwitchBot/Pages/MusicPlayer.razor
@@ -8,6 +8,7 @@
 @implements IAsyncDisposable
 @inject ISnackbar Snackbar
 @inject ILogger<MusicPlayer> logger
+@inject IDialogService DialogService
 
 <PageTitle>@(AppConfiguration["ApplicationTitle"] ?? "Penguin Twitch Bot") - Music Player</PageTitle>
 <MudContainer Class="pa-4" MaxWidth="MaxWidth.ExtraExtraLarge">
@@ -322,7 +323,14 @@
 
     private async Task RemoveSongFromPlaylist((Song song, int playlistId) args)
     {
-        await YtPlayer.RemoveSongFromPlaylist(args.song, args.playlistId);
+        bool? result = await DialogService.ShowMessageBoxAsync(
+        "Warning",
+        "Deleting can not be undone!",
+        yesText: "Delete!", cancelText: "Cancel");
+        if (result != null)
+        {
+            await YtPlayer.RemoveSongFromPlaylist(args.song, args.playlistId);
+        }
     }
 
     private async Task<Dictionary<int, string>> GetPlaylistsForSong(Song song)

--- a/PenguinTwitchBot/Pages/MusicPlayer.razor
+++ b/PenguinTwitchBot/Pages/MusicPlayer.razor
@@ -141,86 +141,15 @@
             @if (musicPlaylists != null)
             {
                 <MudItem xs="12" md="4">
-                    <MudPaper Elevation="3">
-                        <MudTable Items="@musicPlaylists" Dense="true" Hover="true">
-                            <ToolBarContent>
-                                <MudIcon Icon="@Icons.Material.Filled.LibraryMusic" Color="Color.Secondary" Class="mr-2" />
-                                <MudText Typo="Typo.h6">Playlists</MudText>
-                            </ToolBarContent>
-                            <HeaderContent>
-                                <MudTh>Name</MudTh>
-                                <MudTh>Load</MudTh>
-                            </HeaderContent>
-                            <RowTemplate>
-                                <MudTd DataLabel="Name">
-                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                        <MudIcon Icon="@Icons.Material.Filled.PlaylistPlay" Size="Size.Small" Color="Color.Primary" />
-                                        <MudText>@context.Name</MudText>
-                                    </MudStack>
-                                </MudTd>
-                                <MudTd DataLabel="Load">
-                                    <MudTooltip Text="Load Playlist">
-                                        <MudIconButton Icon="@Icons.Material.Filled.PlayArrow" Color="Color.Success" Size="Size.Small"
-                                                       OnClick="() => StartPlaylist(context)" />
-                                    </MudTooltip>
-                                </MudTd>
-                            </RowTemplate>
-                            <NoRecordsContent>
-                                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined">
-                                    No playlists available
-                                </MudAlert>
-                            </NoRecordsContent>
-                        </MudTable>
-                    </MudPaper>
+                    <AvailablePlaylists Playlists="musicPlaylists" DefaultPlaylistId="defaultPlaylistId" AdditionalPlaylistIds="additionalPlaylistIds"
+                                       OnSetDefault="SetDefaultPlaylist" OnToggleAdditional="ToggleAdditionalPlaylist" OnRefresh="RefreshUnplayedSongs" />
                 </MudItem>
             }
 
             @if (currentPlayList != null)
             {
                 <MudItem xs="12" md="8">
-                    <MudPaper Elevation="3">
-                        <MudTable Items="@currentPlayList.Songs" Dense="true" Hover="true">
-                            <ToolBarContent>
-                                <MudIcon Icon="@Icons.Material.Filled.Album" Color="Color.Tertiary" Class="mr-2" />
-                                <MudText Typo="Typo.h6">@currentPlayList.Name</MudText>
-                                <MudSpacer />
-                                <MudBadge Content="@currentPlayList.Songs.Count" Color="Color.Info" Overlap="true">
-                                    <MudIcon Icon="@Icons.Material.Filled.MusicNote" Color="Color.Default" />
-                                </MudBadge>
-                            </ToolBarContent>
-                            <HeaderContent>
-                                <MudTh>Title</MudTh>
-                                <MudTh>Length</MudTh>
-                                <MudTh>Actions</MudTh>
-                            </HeaderContent>
-                            <RowTemplate>
-                                <MudTd DataLabel="Title">
-                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                        <MudIcon Icon="@Icons.Material.Filled.MusicNote" Size="Size.Small" Color="Color.Secondary" />
-                                        <MudText>@context.Title</MudText>
-                                    </MudStack>
-                                </MudTd>
-                                <MudTd DataLabel="Duration">@context.Duration</MudTd>
-                                <MudTd DataLabel="Actions">
-                                    <MudStack Row="true" Spacing="1">
-                                        <MudTooltip Text="Add to Queue">
-                                            <MudIconButton Icon="@Icons.Material.Filled.Queue" Color="Color.Primary" Size="Size.Small"
-                                                           OnClick="() => QueueSong(context)" />
-                                        </MudTooltip>
-                                        <MudTooltip Text="Remove from Playlist">
-                                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
-                                                           OnClick="() => RemoveSong(context)" />
-                                        </MudTooltip>
-                                    </MudStack>
-                                </MudTd>
-                            </RowTemplate>
-                            <NoRecordsContent>
-                                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.PlaylistRemove">
-                                    Playlist is empty
-                                </MudAlert>
-                            </NoRecordsContent>
-                        </MudTable>
-                    </MudPaper>
+                    <CurrentPlaylist Playlist="currentPlayList" OnQueueSong="QueueSong" OnRemoveSong="RemoveSong" />
                 </MudItem>
             }
         </MudGrid>
@@ -239,6 +168,8 @@
     private HubConnection? hubConnection;
     private CancellationTokenSource? _hubConnectionCts;
     private string? addSongUrl;
+    private int? defaultPlaylistId;
+    private List<int> additionalPlaylistIds = new();
     [Inject]
     private IJSRuntime JsRuntime { get; set; } = default!;
 
@@ -253,7 +184,11 @@
         musicPlaylists = await YtPlayer.Playlists();
         currentPlayList = await YtPlayer.CurrentPlaylist();
         currentSong = YtPlayer.GetCurrentSong();
-
+        if (currentPlayList != null && currentPlayList.Id.HasValue)
+        {
+            defaultPlaylistId = currentPlayList.Id.Value;
+            additionalPlaylistIds = await YtPlayer.GetAdditionalPlaylistIds();
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -327,12 +262,40 @@
         await hubConnection.StartWithExpectedExceptionHandlingAsync(logger, Snackbar, _hubConnectionCts.Token);
     }
 
-    private async Task StartPlaylist(MusicPlaylist musicPlaylist)
+    private async Task SetDefaultPlaylist(MusicPlaylist musicPlaylist)
     {
         if (musicPlaylist != null && musicPlaylist.Id != null)
         {
-            await YtPlayer.LoadPlayList((int)musicPlaylist.Id);
+            await YtPlayer.SetPlaylists(musicPlaylist.Id, additionalPlaylistIds);
+            defaultPlaylistId = musicPlaylist.Id.Value;
+            currentPlayList = await YtPlayer.CurrentPlaylist();
+            StateHasChanged();
         }
+    }
+
+    private async Task ToggleAdditionalPlaylist((MusicPlaylist, bool) args)
+    {
+        var (playlist, isChecked) = args;
+        if (playlist == null || playlist.Id == null || defaultPlaylistId == playlist.Id) return;
+        if (isChecked)
+        {
+            if (!additionalPlaylistIds.Contains(playlist.Id.Value))
+                additionalPlaylistIds.Add(playlist.Id.Value);
+        }
+        else
+        {
+            additionalPlaylistIds.Remove(playlist.Id.Value);
+        }
+        await YtPlayer.SetPlaylists(defaultPlaylistId, additionalPlaylistIds);
+        currentPlayList = await YtPlayer.CurrentPlaylist();
+        StateHasChanged();
+    }
+
+    private async Task RefreshUnplayedSongs()
+    {
+        await YtPlayer.RefreshUnplayedSongs();
+        currentPlayList = await YtPlayer.CurrentPlaylist();
+        StateHasChanged();
     }
 
     private async Task Priority(Song song)

--- a/PenguinTwitchBot/Pages/MusicPlayer.razor
+++ b/PenguinTwitchBot/Pages/MusicPlayer.razor
@@ -184,11 +184,8 @@
         musicPlaylists = await YtPlayer.Playlists();
         currentPlayList = await YtPlayer.CurrentPlaylist();
         currentSong = YtPlayer.GetCurrentSong();
-        if (currentPlayList != null && currentPlayList.Id.HasValue)
-        {
-            defaultPlaylistId = currentPlayList.Id.Value;
-            additionalPlaylistIds = await YtPlayer.GetAdditionalPlaylistIds();
-        }
+        defaultPlaylistId = await YtPlayer.GetDefaultPlaylistId();
+        additionalPlaylistIds = await YtPlayer.GetAdditionalPlaylistIds();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/PenguinTwitchBot/Pages/MusicPlayer.razor
+++ b/PenguinTwitchBot/Pages/MusicPlayer.razor
@@ -148,8 +148,19 @@
 
             @if (currentPlayList != null)
             {
+                var selectedNames = new Dictionary<int, string>();
+                if (defaultPlaylistId.HasValue)
+                {
+                    selectedNames[defaultPlaylistId.Value] = musicPlaylists?.FirstOrDefault(p => p.Id == defaultPlaylistId)?.Name ?? $"Playlist {defaultPlaylistId}";
+                }
+                foreach (var id in additionalPlaylistIds)
+                {
+                    selectedNames[id] = musicPlaylists?.FirstOrDefault(p => p.Id == id)?.Name ?? $"Playlist {id}";
+                }
                 <MudItem xs="12" md="8">
-                    <CurrentPlaylist Playlist="currentPlayList" OnQueueSong="QueueSong" OnRemoveSong="RemoveSong" />
+                    <CurrentPlaylist Playlist="currentPlayList" OnQueueSong="QueueSong" OnRemoveSongFrom="RemoveSongFromPlaylist"
+                                     SelectedPlaylistIds="(defaultPlaylistId.HasValue ? new[] { defaultPlaylistId.Value } : Enumerable.Empty<int>()).Concat(additionalPlaylistIds).ToList()"
+                                     SelectedPlaylistNames="selectedNames" />
                 </MudItem>
             }
         </MudGrid>
@@ -270,8 +281,10 @@
     {
         if (musicPlaylist != null && musicPlaylist.Id != null)
         {
-            await YtPlayer.SetPlaylists(musicPlaylist.Id, additionalPlaylistIds);
-            defaultPlaylistId = musicPlaylist.Id.Value;
+            var newDefaultId = musicPlaylist.Id.Value;
+            additionalPlaylistIds.Remove(newDefaultId);
+            await YtPlayer.SetPlaylists(newDefaultId, additionalPlaylistIds);
+            defaultPlaylistId = newDefaultId;
             currentPlayList = await YtPlayer.CurrentPlaylist();
             StateHasChanged();
         }
@@ -281,6 +294,11 @@
     {
         var (playlist, isChecked) = args;
         if (playlist == null || playlist.Id == null || defaultPlaylistId == playlist.Id) return;
+        if (defaultPlaylistId == null)
+        {
+            Snackbar.Add("Set a default playlist before enabling additional playlists.", Severity.Warning);
+            return;
+        }
         if (isChecked)
         {
             if (!additionalPlaylistIds.Contains(playlist.Id.Value))
@@ -310,6 +328,11 @@
     private async Task RemoveSong(Song song)
     {
         await YtPlayer.RemoveSong(song);
+    }
+
+    private async Task RemoveSongFromPlaylist((Song song, int playlistId) args)
+    {
+        await YtPlayer.RemoveSongFromPlaylist(args.song, args.playlistId);
     }
 
     private async Task QueueSong(Song song)

--- a/PenguinTwitchBot/Pages/MusicPlayer.razor
+++ b/PenguinTwitchBot/Pages/MusicPlayer.razor
@@ -148,19 +148,9 @@
 
             @if (currentPlayList != null)
             {
-                var selectedNames = new Dictionary<int, string>();
-                if (defaultPlaylistId.HasValue)
-                {
-                    selectedNames[defaultPlaylistId.Value] = musicPlaylists?.FirstOrDefault(p => p.Id == defaultPlaylistId)?.Name ?? $"Playlist {defaultPlaylistId}";
-                }
-                foreach (var id in additionalPlaylistIds)
-                {
-                    selectedNames[id] = musicPlaylists?.FirstOrDefault(p => p.Id == id)?.Name ?? $"Playlist {id}";
-                }
                 <MudItem xs="12" md="8">
                     <CurrentPlaylist Playlist="currentPlayList" OnQueueSong="QueueSong" OnRemoveSongFrom="RemoveSongFromPlaylist"
-                                     SelectedPlaylistIds="(defaultPlaylistId.HasValue ? new[] { defaultPlaylistId.Value } : Enumerable.Empty<int>()).Concat(additionalPlaylistIds).ToList()"
-                                     SelectedPlaylistNames="selectedNames" />
+                                     OnGetPlaylistsForSong="GetPlaylistsForSong" />
                 </MudItem>
             }
         </MudGrid>
@@ -333,6 +323,16 @@
     private async Task RemoveSongFromPlaylist((Song song, int playlistId) args)
     {
         await YtPlayer.RemoveSongFromPlaylist(args.song, args.playlistId);
+    }
+
+    private async Task<Dictionary<int, string>> GetPlaylistsForSong(Song song)
+    {
+        var allIds = new List<int>();
+        if (defaultPlaylistId.HasValue)
+            allIds.Add(defaultPlaylistId.Value);
+        allIds.AddRange(additionalPlaylistIds);
+        var result = await YtPlayer.GetPlaylistsContainingSong(song.SongId, allIds);
+        return result;
     }
 
     private async Task QueueSong(Song song)

--- a/PenguinTwitchBot/Pages/MusicPlayer.razor
+++ b/PenguinTwitchBot/Pages/MusicPlayer.razor
@@ -217,6 +217,7 @@
                     } else
                     {
                         await JsRuntime.InvokeAsync<string>("playVideo", await YtPlayer.GetNextSong());
+                        currentSong = YtPlayer.GetCurrentSong();
                     }
 
                     _timer?.Dispose();
@@ -260,6 +261,12 @@
         });
 
         await hubConnection.StartWithExpectedExceptionHandlingAsync(logger, Snackbar, _hubConnectionCts.Token);
+
+        currentSong = YtPlayer.GetCurrentSong();
+        if (currentSong != null)
+        {
+            StateHasChanged();
+        }
     }
 
     private async Task SetDefaultPlaylist(MusicPlaylist musicPlaylist)

--- a/PenguinTwitchBot/Pages/PlayLists.razor
+++ b/PenguinTwitchBot/Pages/PlayLists.razor
@@ -63,11 +63,8 @@
         musicPlaylists = await YtPlayer.Playlists();
         currentPlayList = await YtPlayer.CurrentPlaylist();
         currentSong = YtPlayer.GetCurrentSong();
-        if (currentPlayList != null && currentPlayList.Id.HasValue)
-        {
-            defaultPlaylistId = currentPlayList.Id.Value;
-            additionalPlaylistIds = await YtPlayer.GetAdditionalPlaylistIds();
-        }
+        defaultPlaylistId = await YtPlayer.GetDefaultPlaylistId();
+        additionalPlaylistIds = await YtPlayer.GetAdditionalPlaylistIds();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)

--- a/PenguinTwitchBot/Pages/PlayLists.razor
+++ b/PenguinTwitchBot/Pages/PlayLists.razor
@@ -40,7 +40,7 @@
             @if (currentPlayList != null)
             {
                 <MudItem xs="12" md="8">
-                    <CurrentPlaylist Playlist="currentPlayList" OnRemoveSong="RemoveSong" />
+                    <CurrentPlaylist Playlist="currentPlayList" OnRemoveSongFrom="RemoveSongFromPlaylist" OnGetPlaylistsForSong="GetPlaylistsForSong" />
                 </MudItem>
             }
         </MudGrid>
@@ -182,7 +182,7 @@
         await YtPlayer.MoveSongToNext(song.SongId);
     }
 
-    private async Task RemoveSong(Song song)
+    private async Task RemoveSongFromPlaylist((Song song, int playlistId) args)
     {
         bool? result = await DialogService.ShowMessageBoxAsync(
         "Warning",
@@ -190,8 +190,18 @@
         yesText: "Delete!", cancelText: "Cancel");
         if (result != null)
         {
-            await YtPlayer.RemoveSong(song);
+            await YtPlayer.RemoveSongFromPlaylist(args.song, args.playlistId);
         }
+    }
+
+    private async Task<Dictionary<int, string>> GetPlaylistsForSong(Song song)
+    {
+        var allIds = new List<int>();
+        if (defaultPlaylistId.HasValue)
+            allIds.Add(defaultPlaylistId.Value);
+        allIds.AddRange(additionalPlaylistIds);
+        var result = await YtPlayer.GetPlaylistsContainingSong(song.SongId, allIds);
+        return result;
     }
 
     private async Task RemoveSongRequest(Song song)

--- a/PenguinTwitchBot/Pages/PlayLists.razor
+++ b/PenguinTwitchBot/Pages/PlayLists.razor
@@ -116,8 +116,10 @@
     {
         if (musicPlaylist != null && musicPlaylist.Id != null)
         {
-            await YtPlayer.SetPlaylists(musicPlaylist.Id, additionalPlaylistIds);
-            defaultPlaylistId = musicPlaylist.Id.Value;
+            var newDefaultId = musicPlaylist.Id.Value;
+            additionalPlaylistIds.Remove(newDefaultId);
+            await YtPlayer.SetPlaylists(newDefaultId, additionalPlaylistIds);
+            defaultPlaylistId = newDefaultId;
             currentPlayList = await YtPlayer.CurrentPlaylist();
             StateHasChanged();
         }
@@ -127,6 +129,11 @@
     {
         var (playlist, isChecked) = args;
         if (playlist == null || playlist.Id == null || defaultPlaylistId == playlist.Id) return;
+        if (defaultPlaylistId == null)
+        {
+            Snackbar.Add("Set a default playlist before enabling additional playlists.", Severity.Warning);
+            return;
+        }
         if (isChecked)
         {
             if (!additionalPlaylistIds.Contains(playlist.Id.Value))

--- a/PenguinTwitchBot/Pages/PlayLists.razor
+++ b/PenguinTwitchBot/Pages/PlayLists.razor
@@ -18,208 +18,29 @@
         </MudText>
 
         <MudGrid Spacing="3">
-            @if (currentSong != null)
-            {
-                <MudItem xs="12" md="4">
-                    <MudPaper Elevation="3" Class="pa-4">
-                        <MudStack Spacing="2">
-                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                                <MudIcon Icon="@Icons.Material.Filled.PlayCircle" Color="Color.Success" Size="Size.Large" />
-                                <MudText Typo="Typo.h6" Color="Color.Success">Now Playing</MudText>
-                            </MudStack>
-                            <MudDivider />
-                            <MudStack Spacing="1">
-                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                    <MudIcon Icon="@Icons.Material.Filled.MusicNote" Size="Size.Small" Color="Color.Primary" />
-                                    <MudText Typo="Typo.subtitle1"><strong>@currentSong.Title</strong></MudText>
-                                </MudStack>
-                                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                    <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Small" Color="Color.Secondary" />
-                                    <MudText Typo="Typo.body2">Requested by <strong>@currentSong.RequestedBy</strong></MudText>
-                                </MudStack>
-                            </MudStack>
-                            <MudDivider />
-                            @if (YtPlayer.SongExistsInBackupList(currentSong))
-                            {
-                                <MudButton Variant="Variant.Filled" Color="Color.Default" Disabled="true" StartIcon="@Icons.Material.Filled.CheckCircle">
-                                    Already in Playlist
-                                </MudButton>
-                            }
-                            else
-                            {
-                                <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="StealSong" StartIcon="@Icons.Material.Filled.LibraryAdd">
-                                    Steal Song
-                                </MudButton>
-                            }
-                        </MudStack>
-                    </MudPaper>
-                </MudItem>
-            }
-
             @if (musicPlaylists != null)
             {
-                <MudItem xs="12" md="@(currentSong != null ? 8 : 12)">
-                    <MudPaper Elevation="3">
-                        <MudTable Items="@musicPlaylists" Dense="true" Hover="true">
-                            <ToolBarContent>
-                                <MudIcon Icon="@Icons.Material.Filled.LibraryMusic" Color="Color.Secondary" Class="mr-2" />
-                                <MudText Typo="Typo.h6">Available Playlists</MudText>
-                                <MudSpacer />
-                                <MudButton Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small"
-                                           StartIcon="@Icons.Custom.Brands.YouTube" OnClick="ImportFromYouTube" Class="mr-2">
-                                    Import from YouTube
-                                </MudButton>
-                                <MudBadge Content="@musicPlaylists.Count" Color="Color.Info" Overlap="true">
-                                    <MudIcon Icon="@Icons.Material.Filled.PlaylistPlay" Color="Color.Default" />
-                                </MudBadge>
-                            </ToolBarContent>
-                            <HeaderContent>
-                                <MudTh>Playlist Name</MudTh>
-                                <MudTh>Actions</MudTh>
-                            </HeaderContent>
-                            <RowTemplate>
-                                <MudTd DataLabel="Name">
-                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                        <MudIcon Icon="@Icons.Material.Filled.PlaylistPlay" Size="Size.Small" Color="Color.Primary" />
-                                        <MudText><strong>@context.Name</strong></MudText>
-                                    </MudStack>
-                                </MudTd>
-                                <MudTd DataLabel="Actions">
-                                    <MudStack Row="true" Spacing="1">
-                                        <MudButton Variant="Variant.Outlined" Color="Color.Success" Size="Size.Small"
-                                                   StartIcon="@Icons.Material.Filled.PlayArrow"
-                                                   OnClick="() => StartPlaylist(context)">
-                                            Load
-                                        </MudButton>
-                                        <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small"
-                                                   StartIcon="@Icons.Material.Filled.Visibility"
-                                                   OnClick="() => ViewList(context)">
-                                            View
-                                        </MudButton>
-                                        <MudButton Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small"
-                                                   StartIcon="@Icons.Material.Filled.Delete"
-                                                   OnClick="() => DeletePlaylist(context)">
-                                            Delete
-                                        </MudButton>
-                                    </MudStack>
-                                </MudTd>
-                            </RowTemplate>
-                            <NoRecordsContent>
-                                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.PlaylistRemove">
-                                    No playlists available
-                                </MudAlert>
-                            </NoRecordsContent>
-                        </MudTable>
-                    </MudPaper>
+                <MudItem xs="12" md="4">
+                    <AvailablePlaylists Playlists="musicPlaylists" DefaultPlaylistId="defaultPlaylistId" AdditionalPlaylistIds="additionalPlaylistIds"
+                                       OnSetDefault="SetDefaultPlaylist" OnToggleAdditional="ToggleAdditionalPlaylist" OnView="ViewList" OnDelete="DeletePlaylist" OnRefresh="RefreshUnplayedSongs">
+                        <ToolBarContent>
+                            <MudSpacer />
+                            <MudButton Variant="Variant.Outlined" Color="Color.Error" Size="Size.Small"
+                                       StartIcon="@Icons.Custom.Brands.YouTube" OnClick="ImportFromYouTube" Class="mr-2">
+                                Import from YouTube
+                            </MudButton>
+                            <MudButton Variant="Variant.Outlined" Color="Color.Primary" Size="Size.Small"
+                                       StartIcon="@Icons.Material.Filled.Add" OnClick="CreateBlankPlaylist">
+                                New Playlist
+                            </MudButton>
+                        </ToolBarContent>
+                    </AvailablePlaylists>
                 </MudItem>
             }
-
-            @if (songRequests != null)
-            {
-                <MudItem xs="12" md="8">
-                    <MudPaper Elevation="3">
-                        <MudTable Items="@songRequests" Dense="true" Hover="true">
-                            <ToolBarContent>
-                                <MudIcon Icon="@Icons.Material.Filled.QueueMusic" Color="Color.Primary" Class="mr-2" />
-                                <MudText Typo="Typo.h6">Song Requests</MudText>
-                                <MudSpacer />
-                                <MudBadge Content="@songRequests.Count" Color="Color.Info" Overlap="true">
-                                    <MudIcon Icon="@Icons.Material.Filled.MusicNote" Color="Color.Default" />
-                                </MudBadge>
-                            </ToolBarContent>
-                            <HeaderContent>
-                                <MudTh>Title</MudTh>
-                                <MudTh>Length</MudTh>
-                                <MudTh>Requested By</MudTh>
-                                <MudTh>Actions</MudTh>
-                            </HeaderContent>
-                            <RowTemplate>
-                                <MudTd DataLabel="Title">
-                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                        <MudIcon Icon="@Icons.Material.Filled.MusicNote" Size="Size.Small" Color="Color.Secondary" />
-                                        <MudText>@context.Title</MudText>
-                                    </MudStack>
-                                </MudTd>
-                                <MudTd DataLabel="Duration">
-                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                        <MudIcon Icon="@Icons.Material.Filled.AccessTime" Size="Size.Small" Color="Color.Info" />
-                                        <MudText>@context.Duration</MudText>
-                                    </MudStack>
-                                </MudTd>
-                                <MudTd DataLabel="Requested By">
-                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                        <MudIcon Icon="@Icons.Material.Filled.Person" Size="Size.Small" Color="Color.Success" />
-                                        <MudText>@context.RequestedBy</MudText>
-                                    </MudStack>
-                                </MudTd>
-                                <MudTd DataLabel="Actions">
-                                    <MudStack Row="true" Spacing="1">
-                                        <MudTooltip Text="Move to Next">
-                                            <MudIconButton Icon="@Icons.Material.Filled.PriorityHigh" Color="Color.Warning" Size="Size.Small"
-                                                           OnClick="() => Priority(context)" />
-                                        </MudTooltip>
-                                        <MudTooltip Text="Remove Request">
-                                            <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
-                                                           OnClick="() => RemoveSongRequest(context)" />
-                                        </MudTooltip>
-                                    </MudStack>
-                                </MudTd>
-                            </RowTemplate>
-                            <NoRecordsContent>
-                                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.MusicOff">
-                                    No song requests in queue
-                                </MudAlert>
-                            </NoRecordsContent>
-                        </MudTable>
-                    </MudPaper>
-                </MudItem>
-            }
-
             @if (currentPlayList != null)
             {
-                <MudItem xs="12" md="@(songRequests != null ? 12 : 8)">
-                    <MudPaper Elevation="3">
-                        <MudTable Items="@currentPlayList.Songs" Dense="true" Hover="true">
-                            <ToolBarContent>
-                                <MudIcon Icon="@Icons.Material.Filled.Album" Color="Color.Tertiary" Class="mr-2" />
-                                <MudText Typo="Typo.h6">Current Playlist: @currentPlayList.Name</MudText>
-                                <MudSpacer />
-                                <MudBadge Content="@currentPlayList.Songs.Count" Color="Color.Info" Overlap="true">
-                                    <MudIcon Icon="@Icons.Material.Filled.MusicNote" Color="Color.Default" />
-                                </MudBadge>
-                            </ToolBarContent>
-                            <HeaderContent>
-                                <MudTh>Title</MudTh>
-                                <MudTh>Length</MudTh>
-                                <MudTh>Actions</MudTh>
-                            </HeaderContent>
-                            <RowTemplate>
-                                <MudTd DataLabel="Title">
-                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                        <MudIcon Icon="@Icons.Material.Filled.MusicNote" Size="Size.Small" Color="Color.Secondary" />
-                                        <MudText>@context.Title</MudText>
-                                    </MudStack>
-                                </MudTd>
-                                <MudTd DataLabel="Duration">
-                                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
-                                        <MudIcon Icon="@Icons.Material.Filled.AccessTime" Size="Size.Small" Color="Color.Info" />
-                                        <MudText>@context.Duration</MudText>
-                                    </MudStack>
-                                </MudTd>
-                                <MudTd DataLabel="Actions">
-                                    <MudTooltip Text="Remove from Playlist">
-                                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Color="Color.Error" Size="Size.Small"
-                                                       OnClick="() => RemoveSong(context)" />
-                                    </MudTooltip>
-                                </MudTd>
-                            </RowTemplate>
-                            <NoRecordsContent>
-                                <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.PlaylistRemove">
-                                    Playlist is empty
-                                </MudAlert>
-                            </NoRecordsContent>
-                        </MudTable>
-                    </MudPaper>
+                <MudItem xs="12" md="8">
+                    <CurrentPlaylist Playlist="currentPlayList" OnRemoveSong="RemoveSong" />
                 </MudItem>
             }
         </MudGrid>
@@ -233,6 +54,8 @@
     private List<Song>? songRequests;
     private HubConnection? hubConnection;
     private CancellationTokenSource? _hubConnectionCts;
+    private int? defaultPlaylistId;
+    private List<int> additionalPlaylistIds = new();
     [Inject] private IDialogService DialogService { get; set; } = default!;
 
     protected override async Task OnInitializedAsync()
@@ -240,6 +63,11 @@
         musicPlaylists = await YtPlayer.Playlists();
         currentPlayList = await YtPlayer.CurrentPlaylist();
         currentSong = YtPlayer.GetCurrentSong();
+        if (currentPlayList != null && currentPlayList.Id.HasValue)
+        {
+            defaultPlaylistId = currentPlayList.Id.Value;
+            additionalPlaylistIds = await YtPlayer.GetAdditionalPlaylistIds();
+        }
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -287,12 +115,62 @@
         navigationManager.NavigateTo($"/viewplaylist/{musicPlaylist.Id}");
     }
 
-    private async Task StartPlaylist(MusicPlaylist musicPlaylist)
+    private async Task SetDefaultPlaylist(MusicPlaylist musicPlaylist)
     {
         if (musicPlaylist != null && musicPlaylist.Id != null)
         {
-            await YtPlayer.LoadPlayList((int)musicPlaylist.Id);
+            await YtPlayer.SetPlaylists(musicPlaylist.Id, additionalPlaylistIds);
+            defaultPlaylistId = musicPlaylist.Id.Value;
+            currentPlayList = await YtPlayer.CurrentPlaylist();
             StateHasChanged();
+        }
+    }
+
+    private async Task ToggleAdditionalPlaylist((MusicPlaylist, bool) args)
+    {
+        var (playlist, isChecked) = args;
+        if (playlist == null || playlist.Id == null || defaultPlaylistId == playlist.Id) return;
+        if (isChecked)
+        {
+            if (!additionalPlaylistIds.Contains(playlist.Id.Value))
+                additionalPlaylistIds.Add(playlist.Id.Value);
+        }
+        else
+        {
+            additionalPlaylistIds.Remove(playlist.Id.Value);
+        }
+        await YtPlayer.SetPlaylists(defaultPlaylistId, additionalPlaylistIds);
+        currentPlayList = await YtPlayer.CurrentPlaylist();
+        StateHasChanged();
+    }
+
+    private async Task RefreshUnplayedSongs()
+    {
+        await YtPlayer.RefreshUnplayedSongs();
+        currentPlayList = await YtPlayer.CurrentPlaylist();
+        StateHasChanged();
+    }
+
+    private async Task CreateBlankPlaylist()
+    {
+        var parameters = new DialogParameters<CreatePlaylistDialog>();
+        var options = new DialogOptions { CloseOnEscapeKey = true, MaxWidth = MaxWidth.Small, FullWidth = true };
+        var dialog = await DialogService.ShowAsync<CreatePlaylistDialog>("Create New Playlist", parameters, options);
+        var result = await dialog.Result;
+        if (result is not null && !result.Canceled && result.Data is string playlistName)
+        {
+            try
+            {
+                await YtPlayer.CreatePlaylist(playlistName);
+                musicPlaylists = await YtPlayer.Playlists();
+                Snackbar.Add($"Playlist '{playlistName}' created.", Severity.Success);
+                StateHasChanged();
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to create playlist");
+                Snackbar.Add("Failed to create playlist.", Severity.Error);
+            }
         }
     }
     private async Task Priority(Song song)

--- a/PenguinTwitchBot/_Imports.razor
+++ b/PenguinTwitchBot/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.JSInterop
 @using Microsoft.Extensions.Configuration
 @using PenguinTwitchBot
+@using PenguinTwitchBot.Pages.Components
 @using PenguinTwitchBot.Shared
 @using MudBlazor
 @using BlazorTime


### PR DESCRIPTION
Update so multiple playlists can be enabled at same time. This allows a default for when adding to an existing playlist it goes to the default while loading the others. It chooses distinct list of all songs. This also allows to make empty playlists now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Add a configurable default playlist with optional additional playlists to create a de-duplicated “multi playlist” view.
  * Create playlists via a new dialog.
  * New UI components for listing available playlists and managing the current playlist (view, delete, set/unset default, toggle additional, refresh unplayed songs).

* **Improvements**
  * Current playlist now includes search filtering and dialog-based song removal across selected playlists.
  * Playlist selection and unplayed queue refresh automatically during playback.

* **Bug Fixes**
  * Song add/remove actions now stay consistent between the active view and saved playlists.

* **Chores**
  * Updated state updates to use async task handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->