### PR TITLE
Makes backups more resilent and fix the solution

### DIFF
--- a/PenguinTwitchBot.Database/Bot/Actions/SubActions/Types/AlertType.cs
+++ b/PenguinTwitchBot.Database/Bot/Actions/SubActions/Types/AlertType.cs
@@ -1,4 +1,3 @@
-using PenguinTwitchBot.Database.Bot.Actions.SubActions;
 using PenguinTwitchBot.Database.Bot.Actions.SubActions.UI;
 
 namespace PenguinTwitchBot.Database.Bot.Actions.SubActions.Types

--- a/PenguinTwitchBot.Database/Bot/DatabaseTools/BackupTools.cs
+++ b/PenguinTwitchBot.Database/Bot/DatabaseTools/BackupTools.cs
@@ -89,10 +89,12 @@ namespace PenguinTwitchBot.Database.Bot.DatabaseTools
                 Directory.CreateDirectory(backupDirectory);
             }
 
-            if (!Directory.Exists(tempDirectory))
+            if(Directory.Exists(tempDirectory))
             {
-                Directory.CreateDirectory(tempDirectory);
+                Directory.Delete(tempDirectory, true);
             }
+            Directory.CreateDirectory(tempDirectory);
+            
             var handlers = AppDomain.CurrentDomain.GetAssemblies()
             .SelectMany(s => s.GetTypes())
             .Where(p => typeof(IBackupDb).IsAssignableFrom(p) && p.IsClass && p.FullName?.Contains("GenericRepository") == false);

--- a/PenguinTwitchBot.sln
+++ b/PenguinTwitchBot.sln
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PenguinTwitchBot.TwitchApi"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PenguinTwitchBot.TwitchApi.Test", "PenguinTwitchBot.TwitchApi.Test\PenguinTwitchBot.TwitchApi.Test.csproj", "{5C4C6887-7098-454E-A372-B572DA86BDC4}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PenguinTwitchBot.Database", "PenguinTwitchBot.Database\PenguinTwitchBot.Database.csproj", "{B6D2A781-F372-4712-B6E9-90FA1C9F4E34}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/PenguinTwitchBot/Bot/Commands/Moderation/Admin.cs
+++ b/PenguinTwitchBot/Bot/Commands/Moderation/Admin.cs
@@ -17,19 +17,25 @@ namespace PenguinTwitchBot.Bot.Commands.Moderation
     {
         public async Task BackupDatabase()
         {
-            await using var scope = scopeFactory.CreateAsyncScope();
-            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-            await BackupTools.BackupDatabase(db, BackupTools.BACKUP_DIRECTORY, logger);
-            var files = Directory.GetFiles(BackupTools.BACKUP_DIRECTORY);
-            logger.LogInformation("Deleting old backups > 30 days");
-            foreach (var file in files)
+            try
             {
-                FileInfo fi = new(file);
-                if (fi.CreationTime < DateTime.Now.AddDays(-30))
+                await using var scope = scopeFactory.CreateAsyncScope();
+                var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+                await BackupTools.BackupDatabase(db, BackupTools.BACKUP_DIRECTORY, logger);
+                var files = Directory.GetFiles(BackupTools.BACKUP_DIRECTORY);
+                logger.LogInformation("Deleting old backups > 30 days");
+                foreach (var file in files)
                 {
-                    logger.LogInformation("Deleting backup: {name}", fi.Name);
-                    fi.Delete();
+                    FileInfo fi = new(file);
+                    if (fi.CreationTime < DateTime.Now.AddDays(-30))
+                    {
+                        logger.LogInformation("Deleting backup: {name}", fi.Name);
+                        fi.Delete();
+                    }
                 }
+            } catch (Exception ex)
+            {
+                logger.LogCritical(ex, "ERROR ERROR Error backing up database! ERROR ERROR");
             }
         }
 


### PR DESCRIPTION
* If a backup fails, it doesn't prevent the bot from starting
* It checks to see if the temp directory exists and deletes it if it does then recreates it for the actual backup now


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backup reliability by ensuring temporary backup storage starts clean before a backup runs.
  - Added safer error handling during backup and cleanup so failures are logged instead of unexpectedly interrupting the process.
  - Reduced the chance of backup issues caused by leftover files from previous runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->