### PR TITLE
Optimizes viewer lookup

### DIFF
--- a/PenguinTwitchBot.Database/Bot/DatabaseTools/BackupTools.cs
+++ b/PenguinTwitchBot.Database/Bot/DatabaseTools/BackupTools.cs
@@ -83,16 +83,12 @@ namespace PenguinTwitchBot.Database.Bot.DatabaseTools
         public static async Task BackupDatabase(DbContext context, string backupDirectory, ILogger logger)
         {
             logger.LogInformation("Backing up database");
-            var tempDirectory = Path.Combine(backupDirectory, "temp");
+            var tempDirectory = Path.Combine(backupDirectory, $"temp-{Guid.NewGuid():N}");
             if (!Directory.Exists(backupDirectory))
             {
                 Directory.CreateDirectory(backupDirectory);
             }
 
-            if(Directory.Exists(tempDirectory))
-            {
-                Directory.Delete(tempDirectory, true);
-            }
             Directory.CreateDirectory(tempDirectory);
             
             var handlers = AppDomain.CurrentDomain.GetAssemblies()

--- a/PenguinTwitchBot.Test/Bot/Commands/Features/ViewerFeatureTests.cs
+++ b/PenguinTwitchBot.Test/Bot/Commands/Features/ViewerFeatureTests.cs
@@ -331,5 +331,67 @@ namespace PenguinTwitchBot.Test.Bot.Commands.Features
             Assert.True(result);
         }
 
+        [Fact]
+        public async Task GetViewerByUserName_SecondCall_DoesNotHitDatabase()
+        {
+            // Arrange
+            dbContext.Viewers.Find(x => true).ReturnsForAnyArgs(viewerQueryable);
+
+            // Act
+            await viewerFeature.GetViewerByUserName("test");
+            await viewerFeature.GetViewerByUserName("test");
+
+            // Assert — DB should only be queried once; second call served from cache
+            dbContext.Viewers.Received(1).Find(Arg.Any<System.Linq.Expressions.Expression<Func<Viewer, bool>>>());
+        }
+
+        [Fact]
+        public async Task GetViewerByUserName_ReturnsCachedViewer_OnSecondCall()
+        {
+            // Arrange
+            dbContext.Viewers.Find(x => true).ReturnsForAnyArgs(viewerQueryable);
+
+            // Act
+            var first = await viewerFeature.GetViewerByUserName("test");
+            var second = await viewerFeature.GetViewerByUserName("test");
+
+            // Assert
+            Assert.Equal(first, second);
+        }
+
+        [Fact]
+        public async Task GetViewerByUserName_CacheIsInvalidated_AfterSaveViewer()
+        {
+            // Arrange
+            dbContext.Viewers.Find(x => true).ReturnsForAnyArgs(viewerQueryable);
+
+            // Prime the cache
+            await viewerFeature.GetViewerByUserName("test");
+
+            // Invalidate via SaveViewer (calls UpdateViewer internally)
+            testViewer.Username = "test";
+            await viewerFeature.SaveViewer(testViewer);
+
+            // Act — should hit DB again after cache invalidation
+            await viewerFeature.GetViewerByUserName("test");
+
+            // Assert — DB queried twice: once before save, once after invalidation
+            dbContext.Viewers.Received(2).Find(Arg.Any<System.Linq.Expressions.Expression<Func<Viewer, bool>>>());
+        }
+
+        [Fact]
+        public async Task GetNameWithTitle_SecondCall_DoesNotHitDatabase()
+        {
+            // Arrange
+            dbContext.Viewers.Find(x => true).ReturnsForAnyArgs(viewerQueryable);
+
+            // Act
+            await viewerFeature.GetNameWithTitle("test");
+            await viewerFeature.GetNameWithTitle("test");
+
+            // Assert — viewer lookup cached; DB only hit once across both calls
+            dbContext.Viewers.Received(1).Find(Arg.Any<System.Linq.Expressions.Expression<Func<Viewer, bool>>>());
+        }
+
     }
 }

--- a/PenguinTwitchBot.Test/Bot/Commands/Metrics/SongRequestsTests.cs
+++ b/PenguinTwitchBot.Test/Bot/Commands/Metrics/SongRequestsTests.cs
@@ -66,6 +66,49 @@ namespace PenguinTwitchBot.Test.Bot.Commands.Metrics
         }
 
         [Fact]
+        public async Task IncrementSongCount_ReturnsOne_OnFirstRequest()
+        {
+            var songRequests = CreateSongRequests();
+            var song = new Song { SongId = "newSong", Title = "New Song", Duration = TimeSpan.FromMinutes(3) };
+
+            var count = await songRequests.IncrementSongCount(song);
+
+            Assert.Equal(1, count);
+        }
+
+        [Fact]
+        public async Task IncrementSongCount_ReturnsIncrementedCount_OnSubsequentRequests()
+        {
+            var songId = "repeatedSong";
+            _context.SongRequestHistories.AddRange(
+                new SongRequestHistory { Id = Guid.NewGuid().ToString(), SongId = songId, Title = "Repeated Song", Duration = TimeSpan.FromMinutes(3), RequestDate = DateTime.UtcNow },
+                new SongRequestHistory { Id = Guid.NewGuid().ToString(), SongId = songId, Title = "Repeated Song", Duration = TimeSpan.FromMinutes(3), RequestDate = DateTime.UtcNow }
+            );
+            await _context.SaveChangesAsync();
+
+            var songRequests = CreateSongRequests();
+            var song = new Song { SongId = songId, Title = "Repeated Song", Duration = TimeSpan.FromMinutes(3) };
+
+            var count = await songRequests.IncrementSongCount(song);
+
+            Assert.Equal(3, count);
+        }
+
+        [Fact]
+        public async Task IncrementSongCount_CountIsIndependentPerSong()
+        {
+            var songRequests = CreateSongRequests();
+            var songA = new Song { SongId = "songA", Title = "Song A", Duration = TimeSpan.FromMinutes(3) };
+            var songB = new Song { SongId = "songB", Title = "Song B", Duration = TimeSpan.FromMinutes(3) };
+
+            await songRequests.IncrementSongCount(songA);
+            await songRequests.IncrementSongCount(songA);
+            var countB = await songRequests.IncrementSongCount(songB);
+
+            Assert.Equal(1, countB);
+        }
+
+        [Fact]
         public async Task GetRequestedCount_ReturnsZero_WhenNoHistory()
         {
             var songRequests = CreateSongRequests();

--- a/PenguinTwitchBot/Bot/Commands/Features/ViewerFeature.cs
+++ b/PenguinTwitchBot/Bot/Commands/Features/ViewerFeature.cs
@@ -335,6 +335,7 @@ namespace PenguinTwitchBot.Bot.Commands.Features
 
         private async Task AddSubscription(string username)
         {
+            _viewerCache.TryRemove(username, out _);
             var viewer = await GetViewerByUserName(username);
             if (viewer == null) return;
             viewer.isSub = true;
@@ -344,6 +345,7 @@ namespace PenguinTwitchBot.Bot.Commands.Features
 
         private async Task RemoveSubscription(string username)
         {
+            _viewerCache.TryRemove(username, out _);
             var viewer = await GetViewerByUserName(username);
             if (viewer == null) return;
             viewer.isSub = false;

--- a/PenguinTwitchBot/Bot/Commands/Features/ViewerFeature.cs
+++ b/PenguinTwitchBot/Bot/Commands/Features/ViewerFeature.cs
@@ -14,6 +14,8 @@ namespace PenguinTwitchBot.Bot.Commands.Features
         private readonly ConcurrentDictionary<string, DateTime> _usersLastActive = new();
         private ConcurrentBag<string> _users = new();
         private readonly ConcurrentDictionary<string, DateTime> _lurkers = new();
+        private readonly ConcurrentDictionary<string, (Viewer Viewer, DateTime CachedAt)> _viewerCache = new();
+        private static readonly TimeSpan ViewerCacheTtl = TimeSpan.FromMinutes(5);
 
         private readonly ITwitchService _twitchService;
         private readonly ILogger<ViewerFeature> _logger;
@@ -144,10 +146,13 @@ namespace PenguinTwitchBot.Bot.Commands.Features
             }
             else
             {
-
                 db.Viewers.Update(viewer);
             }
             await db.SaveChangesAsync();
+            if (!string.IsNullOrEmpty(viewer.Username))
+            {
+                _viewerCache.TryRemove(viewer.Username, out _);
+            }
         }
 
         private async Task UpdateLastSeen(Viewer viewer)
@@ -221,10 +226,14 @@ namespace PenguinTwitchBot.Bot.Commands.Features
         public async Task<Viewer?> GetViewerByUserName(string username)
         {
             var normalizedUsername = UsernameNormalizer.Normalize(username);
+            if (_viewerCache.TryGetValue(normalizedUsername, out var cached) && DateTime.UtcNow - cached.CachedAt < ViewerCacheTtl)
+            {
+                return cached.Viewer;
+            }
             await using var scope = _scopeFactory.CreateAsyncScope();
             var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
             var viewer = await db.Viewers.Find(x => x.Username.Equals(normalizedUsername)).FirstOrDefaultAsync();
-            if(viewer == null)
+            if (viewer == null)
             {
                 var twitchViewer = await _twitchService.GetUserByName(username);
                 if (twitchViewer != null)
@@ -232,7 +241,10 @@ namespace PenguinTwitchBot.Bot.Commands.Features
                     await AddOrUpdateLastSeen(twitchViewer.Id);
                     viewer = await GetViewerByUserId(twitchViewer.Id);
                 }
-
+            }
+            if (viewer != null)
+            {
+                _viewerCache[normalizedUsername] = (viewer, DateTime.UtcNow);
             }
             return viewer;
         }
@@ -465,6 +477,7 @@ namespace PenguinTwitchBot.Bot.Commands.Features
             {
                 _logger.LogError(ex, "Error updating subscribers");
             }
+            _viewerCache.Clear();
         }
 
         public async Task UpdateEditors()
@@ -516,6 +529,7 @@ namespace PenguinTwitchBot.Bot.Commands.Features
             {
                 _logger.LogError(ex, "Error updating editors");
             }
+            _viewerCache.Clear();
         }
 
         public override async Task Register()

--- a/PenguinTwitchBot/Bot/Commands/Metrics/SongRequests.cs
+++ b/PenguinTwitchBot/Bot/Commands/Metrics/SongRequests.cs
@@ -23,7 +23,7 @@ namespace PenguinTwitchBot.Bot.Commands.Metrics
             return Task.CompletedTask;
         }
 
-        public async Task IncrementSongCount(Song song)
+        public async Task<int> IncrementSongCount(Song song)
         {
             await using var scope = scopeFactory.CreateAsyncScope();
             var db = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
@@ -34,6 +34,7 @@ namespace PenguinTwitchBot.Bot.Commands.Metrics
                 Duration = song.Duration
             });
             await db.SaveChangesAsync();
+            return await db.SongRequestHistory.GetRequestedCountForSong(song.SongId);
         }
 
         public async Task DecrementSongCount(Song song)

--- a/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
+++ b/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
@@ -6,6 +6,7 @@ using Google.Apis.YouTube.v3;
 using Microsoft.AspNetCore.SignalR;
 using Prometheus;
 using System.Collections.Concurrent;
+using System.Diagnostics;
 
 namespace PenguinTwitchBot.Bot.Commands.Music
 {
@@ -1084,6 +1085,7 @@ namespace PenguinTwitchBot.Bot.Commands.Music
 
         private async Task SongRequest(CommandEventArgs e)
         {
+            long startTime = Stopwatch.GetTimestamp();
             var songsInQueue = 0;
             try
             {
@@ -1120,7 +1122,7 @@ namespace PenguinTwitchBot.Bot.Commands.Music
                 await ServiceBackbone.ResponseWithMessage(e, $"That song is already in the queue.");
                 throw new SkipCooldownException();
             }
-
+            Console.WriteLine($"1. Elapsed time: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
             var song = await GetSong(searchResult, e.DisplayName);
             if (song == null)
             {
@@ -1144,16 +1146,17 @@ namespace PenguinTwitchBot.Bot.Commands.Music
 
             var timeToWait = new TimeSpan(currentRequestedSongs.Sum(r => r.Duration.Ticks));
             timeToWait += GetCurrentSongTimeLeft();
-
-            await AddSongToRequests(song);
+            Console.WriteLine($"2. Elapsed time: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
+            var songRequestedCount = await AddSongToRequests(song);
+            Console.WriteLine($"3. Elapsed time: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
             if (e.IsWhisper) return;
 
             requestCount++;
-
-            await ServiceBackbone.SendChatMessageWithTitle(e.Name, string.Format("{0} was added in position #{1}, you have a total of {2} requested. Will play in ~{3}. It has been requested {4} times.", song.Title, requestCount, songsInQueue + 1, timeToWait.ToFriendlyString(), await GetSongRequestedCount(song)));
+            await ServiceBackbone.SendChatMessageWithTitle(e.Name, string.Format("{0} was added in position #{1}, you have a total of {2} requested. Will play in ~{3}. It has been requested {4} times.", song.Title, requestCount, songsInQueue + 1, timeToWait.ToFriendlyString(), songRequestedCount));
+            Console.WriteLine($"4. Elapsed time: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
         }
 
-        private async Task AddSongToRequests(Song song)
+        private async Task<int> AddSongToRequests(Song song)
         {
             try
             {
@@ -1166,7 +1169,7 @@ namespace PenguinTwitchBot.Bot.Commands.Music
             NextSong ??= song;
             await using var scope = _scopeFactory.CreateAsyncScope();
             var SongRequestMetrics = scope.ServiceProvider.GetRequiredService<Metrics.SongRequests>();
-            await SongRequestMetrics.IncrementSongCount(song);
+            return await SongRequestMetrics.IncrementSongCount(song);
         }
 
         private static async Task<string> GetSongId(string searchTerm)

--- a/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
+++ b/PenguinTwitchBot/Bot/Commands/Music/YtPlayer.cs
@@ -1085,7 +1085,6 @@ namespace PenguinTwitchBot.Bot.Commands.Music
 
         private async Task SongRequest(CommandEventArgs e)
         {
-            long startTime = Stopwatch.GetTimestamp();
             var songsInQueue = 0;
             try
             {
@@ -1122,7 +1121,6 @@ namespace PenguinTwitchBot.Bot.Commands.Music
                 await ServiceBackbone.ResponseWithMessage(e, $"That song is already in the queue.");
                 throw new SkipCooldownException();
             }
-            Console.WriteLine($"1. Elapsed time: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
             var song = await GetSong(searchResult, e.DisplayName);
             if (song == null)
             {
@@ -1146,14 +1144,11 @@ namespace PenguinTwitchBot.Bot.Commands.Music
 
             var timeToWait = new TimeSpan(currentRequestedSongs.Sum(r => r.Duration.Ticks));
             timeToWait += GetCurrentSongTimeLeft();
-            Console.WriteLine($"2. Elapsed time: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
             var songRequestedCount = await AddSongToRequests(song);
-            Console.WriteLine($"3. Elapsed time: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
             if (e.IsWhisper) return;
 
             requestCount++;
             await ServiceBackbone.SendChatMessageWithTitle(e.Name, string.Format("{0} was added in position #{1}, you have a total of {2} requested. Will play in ~{3}. It has been requested {4} times.", song.Title, requestCount, songsInQueue + 1, timeToWait.ToFriendlyString(), songRequestedCount));
-            Console.WriteLine($"4. Elapsed time: {Stopwatch.GetElapsedTime(startTime).TotalMilliseconds} ms");
         }
 
         private async Task<int> AddSongToRequests(Song song)

--- a/PenguinTwitchBot/Bot/Core/ServiceBackbone.cs
+++ b/PenguinTwitchBot/Bot/Core/ServiceBackbone.cs
@@ -9,6 +9,7 @@ using PenguinTwitchBot.Bot.Events.Chat;
 using PenguinTwitchBot.Bot.Hubs;
 using PenguinTwitchBot.Bot.Notifications;
 using Microsoft.AspNetCore.SignalR;
+using System.Diagnostics;
 
 namespace PenguinTwitchBot.Bot.Core
 {
@@ -138,10 +139,18 @@ namespace PenguinTwitchBot.Bot.Core
             await SendChatMessageWithTitle(viewerName, message, true);
         public async Task SendChatMessageWithTitle(string viewerName, string message, bool sourceOnly)
         {
+            var start = Stopwatch.GetTimestamp();
             using var scope = scopeFactory.CreateAsyncScope();
             var viewerService = scope.ServiceProvider.GetRequiredService<Commands.Features.IViewerFeature>();
             var nameWithTitle = await viewerService.GetNameWithTitle(viewerName);
+            var titleLookupMs = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
             await SendChatMessage(string.Format("{0}, {1}", string.IsNullOrWhiteSpace(nameWithTitle) ? viewerName : nameWithTitle, message));
+            var totalMs = Stopwatch.GetElapsedTime(start).TotalMilliseconds;
+            logger.LogDebug("SendChatMessageWithTitle timing for {Viewer}: titleLookup={TitleLookupMs}ms send={SendMs}ms total={TotalMs}ms",
+                viewerName,
+                Math.Round(titleLookupMs, 2),
+                Math.Round(totalMs - titleLookupMs, 2),
+                Math.Round(totalMs, 2));
         }
 
         public async Task OnStreamStarted()

--- a/PenguinTwitchBot/Pages/BotAuth.razor
+++ b/PenguinTwitchBot/Pages/BotAuth.razor
@@ -11,7 +11,6 @@
     <MudPaper>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" Href="/streamersignin">Auth Streamer</MudButton>
         <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => RefreshBotAuth()">Bot Auth</MudButton>
-        <MudButton Variant="Variant.Filled" Color="Color.Primary" OnClick="() => TestAlert()">Test Alert</MudButton>
         @if(twitchService.IsServiceUp())
         {
             <MudAlert Severity="Severity.Success">Streamer Account is Connected</MudAlert>
@@ -24,11 +23,6 @@
 </MudContainer>
 
 @code {
-    private void TestAlert()
-    {
-        Snackbar.Add("Error connecting to bot. Please refresh. If error persist check your browser version and for any OS updates.", Severity.Error);
-    }
-
     private async Task RefreshBotAuth()
     {
         var result = await twitchChatBot.RefreshAccessToken();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Song requests now show the updated request count immediately after a request is added.
  - Viewer lookups are now cached briefly, which can make repeated profile lookups faster.

- **Bug Fixes**
  - Improved handling of repeated viewer searches and updates to reduce stale or repeated lookups.
  - Fixed song request counting so counts stay accurate across repeated requests and different songs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->