### PR TITLE
Load UI faster by using skeletons instead of blocking spinners

### DIFF
--- a/PenguinTwitchBot.Test/Pages/Commands/ActionCommandsTests.cs
+++ b/PenguinTwitchBot.Test/Pages/Commands/ActionCommandsTests.cs
@@ -145,31 +145,6 @@ namespace PenguinTwitchBot.Test.Pages.Commands
         }
 
         [Fact]
-        public async Task Loading_ShowsSpinner()
-        {
-            SetupContext();
-            var commands = CreateTestCommands();
-            var commandService = new Mock<IActionCommandService>();
-            commandService.Setup(s => s.GetAllAsync()).Returns(async () =>
-            {
-                await Task.Delay(500);
-                return commands;
-            });
-
-            _ctx!.Services.AddSingleton<IActionCommandService>(commandService.Object);
-            _ctx.Services.AddSingleton<IActionManagementService>(new Mock<IActionManagementService>().Object);
-            _ctx.Services.AddSingleton<IPointsSystem>(new Mock<IPointsSystem>().Object);
-            _ctx.Services.AddSingleton<IDialogService>(new Mock<IDialogService>().Object);
-            _ctx.Services.AddSingleton<ISnackbar>(new Mock<ISnackbar>().Object);
-
-            var page = RenderPage();
-            page.WaitForAssertion(() =>
-            {
-                Assert.Contains("Loading commands...", page.Markup);
-            });
-        }
-
-        [Fact]
         public async Task EmptyState_ShowsNoCommands()
         {
             SetupContext();

--- a/PenguinTwitchBot/Helpers/SignalRConnectionHelper.cs
+++ b/PenguinTwitchBot/Helpers/SignalRConnectionHelper.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using MudBlazor;
 using System.Net.Sockets;
 using Microsoft.AspNetCore.Http.Connections.Client;
+using PenguinTwitchBot.Bot.Hubs;
 
 namespace PenguinTwitchBot.Helpers;
 
@@ -93,6 +94,45 @@ public static class SignalRConnectionHelper
                                                socketEx.SocketErrorCode == SocketError.OperationAborted)
         {
             // SocketError.OperationAborted: I/O operation aborted due to thread exit or app request
+            logger.LogDebug("SignalR connection aborted (expected during disposal)");
+            return false;
+        }
+        catch (Exception ex) when (IsExpectedCanceledSignalRStartException(ex))
+        {
+            logger.LogDebug(ex, "SignalR connection startup was canceled (expected during disposal or navigation)");
+            return false;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to establish SignalR connection");
+            snackbar?.Add("Unable to establish live connection. Data may be delayed.", Severity.Warning);
+            return false;
+        }
+    }
+
+    public static async Task<bool> StartWithExpectedExceptionHandlingAsync(
+        this ISignalRHubConnection hubConnection,
+        ILogger logger,
+        ISnackbar? snackbar = null)
+    {
+        try
+        {
+            await hubConnection.StartAsync();
+            return true;
+        }
+        catch (OperationCanceledException)
+        {
+            logger.LogDebug("SignalR connection was canceled (expected during disposal or navigation)");
+            return false;
+        }
+        catch (Microsoft.AspNetCore.SignalR.HubException ex) when (ex.Message.Contains("Handshake was canceled"))
+        {
+            logger.LogDebug("SignalR handshake was canceled (expected during navigation)");
+            return false;
+        }
+        catch (System.IO.IOException ex) when (ex.InnerException is SocketException socketEx &&
+                                               socketEx.SocketErrorCode == SocketError.OperationAborted)
+        {
             logger.LogDebug("SignalR connection aborted (expected during disposal)");
             return false;
         }

--- a/PenguinTwitchBot/Helpers/SignalRConnectionHelper.cs
+++ b/PenguinTwitchBot/Helpers/SignalRConnectionHelper.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using MudBlazor;
 using System.Net.Sockets;
+using Microsoft.AspNetCore.Http.Connections.Client;
 
 namespace PenguinTwitchBot.Helpers;
 
@@ -95,12 +96,73 @@ public static class SignalRConnectionHelper
             logger.LogDebug("SignalR connection aborted (expected during disposal)");
             return false;
         }
+        catch (Exception ex) when (IsExpectedCanceledSignalRStartException(ex))
+        {
+            logger.LogDebug(ex, "SignalR connection startup was canceled (expected during disposal or navigation)");
+            return false;
+        }
         catch (Exception ex)
         {
             logger.LogWarning(ex, "Failed to establish SignalR connection");
             snackbar?.Add("Unable to establish live connection. Data may be delayed.", Severity.Warning);
             return false;
         }
+    }
+
+    private static bool IsExpectedCanceledSignalRStartException(Exception exception)
+    {
+        var allExceptions = (exception as AggregateException)?.Flatten().InnerExceptions ?? [exception];
+        var sawException = false;
+
+        foreach (var innerException in allExceptions)
+        {
+            sawException = true;
+
+            if (innerException is OperationCanceledException || innerException is TaskCanceledException)
+            {
+                continue;
+            }
+
+            if (innerException is TransportFailedException transportFailedException &&
+                ContainsOnlyCancellationExceptions(transportFailedException))
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return sawException;
+    }
+
+    private static bool ContainsOnlyCancellationExceptions(Exception exception)
+    {
+        var allExceptions = (exception as AggregateException)?.Flatten().InnerExceptions ?? [exception];
+
+        foreach (var innerException in allExceptions)
+        {
+            if (ReferenceEquals(innerException, exception))
+            {
+                if (innerException is OperationCanceledException || innerException is TaskCanceledException)
+                {
+                    continue;
+                }
+
+                if (innerException.InnerException is not null && ContainsOnlyCancellationExceptions(innerException.InnerException))
+                {
+                    continue;
+                }
+
+                return false;
+            }
+
+            if (innerException is not OperationCanceledException && innerException is not TaskCanceledException)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/PenguinTwitchBot/Pages/Actions/ActionHistory.razor
+++ b/PenguinTwitchBot/Pages/Actions/ActionHistory.razor
@@ -11,6 +11,7 @@
 @inject NavigationManager NavigationManager
 @inject IActionExecutionLogger ExecutionLogger
 @inject ISignalRHubConnectionFactory HubConnectionFactory
+@inject ILogger<ActionHistory> logger
 @implements IAsyncDisposable
 
 <PageTitle>@(AppConfiguration["ApplicationTitle"] ?? "Penguin Twitch Bot") - Action History</PageTitle>
@@ -256,14 +257,7 @@
                 });
             });
 
-            try
-            {
-                await _hubConnection.StartAsync();
-            }
-            catch (Exception ex)
-            {
-                Snackbar.Add($"Lost connection to bot. Data may be inaccurate until refresh. Error: {ex.Message}", Severity.Warning);
-            }
+            await _hubConnection.StartWithExpectedExceptionHandlingAsync(logger, Snackbar);
         }
     }
 

--- a/PenguinTwitchBot/Pages/Actions/ManageActions.razor
+++ b/PenguinTwitchBot/Pages/Actions/ManageActions.razor
@@ -111,10 +111,20 @@
         <MudItem xs="12" md="8">
             @if (_isLoading)
             {
-                <MudPaper Class="pa-4" Style="height: 80vh; display: flex; align-items: center; justify-content: center;">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="2">
-                        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                        <MudText Typo="Typo.h6" Color="Color.Secondary">Loading actions...</MudText>
+                <MudPaper Class="pa-4" Style="height: 80vh; overflow-y: auto;">
+                    <MudStack Spacing="3">
+                        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="180px" Height="32px" />
+                            <MudStack Row="true" Spacing="1">
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="90px" Height="36px" Class="rounded" />
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100px" Height="36px" Class="rounded" />
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="80px" Height="36px" Class="rounded" />
+                            </MudStack>
+                        </MudStack>
+                        <MudDivider />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="170px" Class="rounded" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="220px" Class="rounded" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="260px" Class="rounded" />
                     </MudStack>
                 </MudPaper>
             }

--- a/PenguinTwitchBot/Pages/Actions/ManageActions.razor
+++ b/PenguinTwitchBot/Pages/Actions/ManageActions.razor
@@ -64,7 +64,25 @@
 
                     <MudDivider />
 
-                    @if (_filteredActions.Count == 0)
+                    @if (_isLoading)
+                    {
+                        <MudStack Spacing="2" Class="pt-2">
+                            @for (var index = 0; index < 5; index++)
+                            {
+                                <MudPaper Elevation="0" Outlined="true" Class="pa-3">
+                                    <MudStack Spacing="1">
+                                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="55%" />
+                                        <MudStack Row="true" Spacing="1">
+                                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="70px" Height="24px" Class="rounded-pill" />
+                                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="90px" Height="24px" Class="rounded-pill" />
+                                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="80px" Height="24px" Class="rounded-pill" />
+                                        </MudStack>
+                                    </MudStack>
+                                </MudPaper>
+                            }
+                        </MudStack>
+                    }
+                    else if (_filteredActions.Count == 0)
                     {
                         <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center" Class="mt-4">
                             No actions found

--- a/PenguinTwitchBot/Pages/Actions/ManageTimers.razor
+++ b/PenguinTwitchBot/Pages/Actions/ManageTimers.razor
@@ -84,10 +84,15 @@
         <MudItem xs="12" md="8">
             @if (_isLoading)
             {
-                <MudPaper Class="pa-4" Style="height: 80vh; display: flex; align-items: center; justify-content: center;">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="2">
-                        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                        <MudText Typo="Typo.h6" Color="Color.Secondary">Loading timer groups...</MudText>
+                <MudPaper Class="pa-4" Style="height: 80vh; overflow-y: auto;">
+                    <MudStack Spacing="3">
+                        <MudStack Row="true" Justify="Justify.SpaceBetween" AlignItems="AlignItems.Center">
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="220px" Height="32px" />
+                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="120px" Height="36px" Class="rounded" />
+                        </MudStack>
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="220px" Class="rounded" />
+                        <MudDivider />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="300px" Class="rounded" />
                     </MudStack>
                 </MudPaper>
             }

--- a/PenguinTwitchBot/Pages/Actions/ManageTimers.razor
+++ b/PenguinTwitchBot/Pages/Actions/ManageTimers.razor
@@ -37,7 +37,25 @@
 
                     <MudDivider />
 
-                    @if (_filteredTimerGroups.Count == 0)
+                    @if (_isLoading)
+                    {
+                        <MudStack Spacing="2" Class="pt-2">
+                            @for (var index = 0; index < 5; index++)
+                            {
+                                <MudPaper Elevation="0" Outlined="true" Class="pa-3">
+                                    <MudStack Spacing="1">
+                                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="60%" />
+                                        <MudStack Row="true" Spacing="1">
+                                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="70px" Height="24px" Class="rounded-pill" />
+                                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="120px" Height="24px" Class="rounded-pill" />
+                                        </MudStack>
+                                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="45%" />
+                                    </MudStack>
+                                </MudPaper>
+                            }
+                        </MudStack>
+                    }
+                    else if (_filteredTimerGroups.Count == 0)
                     {
                         <MudText Typo="Typo.body2" Color="Color.Secondary" Align="Align.Center" Class="mt-4">
                             No timer groups found

--- a/PenguinTwitchBot/Pages/Actions/Queues.razor
+++ b/PenguinTwitchBot/Pages/Actions/Queues.razor
@@ -8,6 +8,7 @@
 @inject IDialogService DialogService
 @inject ISnackbar Snackbar
 @inject NavigationManager NavigationManager
+@inject ILogger<Queues> logger
 @implements IAsyncDisposable
 
 <PageTitle>@(AppConfiguration["ApplicationTitle"] ?? "Penguin Twitch Bot") - Queue Management</PageTitle>
@@ -157,14 +158,7 @@
                 });
             });
 
-            try
-            {
-                await _hubConnection.StartAsync();
-            }
-            catch (Exception ex)
-            {
-                Snackbar.Add($"Lost connection to bot. Data may be inaccurate until refresh. Error: {ex.Message}", Severity.Warning);
-            }
+            await _hubConnection.StartWithExpectedExceptionHandlingAsync(logger, Snackbar);
         }
     }
 

--- a/PenguinTwitchBot/Pages/ChannelPoints.razor
+++ b/PenguinTwitchBot/Pages/ChannelPoints.razor
@@ -41,9 +41,12 @@
 
                     @if (IsLoading)
                     {
-                        <MudStack AlignItems="AlignItems.Center" Class="mt-6" Spacing="2">
-                            <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
-                            <MudText Typo="Typo.body2" Color="Color.Secondary">Loading rewards...</MudText>
+                        <MudStack Class="mt-4" Spacing="2">
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="75%" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="92%" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="88%" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="95%" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="83%" />
                         </MudStack>
                     }
                     else if (FilteredChannelRewards.Count == 0)

--- a/PenguinTwitchBot/Pages/Commands/ActionCommands.razor
+++ b/PenguinTwitchBot/Pages/Commands/ActionCommands.razor
@@ -86,7 +86,7 @@
         <MudItem xs="12" md="8">
             @if (_isLoading)
             {
-                <MudPaper Class="pa-4 loading-spinner" Style="height: 80vh; overflow-y: auto;">
+                <MudPaper Class="pa-4" Style="height: 80vh; overflow-y: auto;">
                     <MudStack Spacing="3">
                         <MudSkeleton SkeletonType="SkeletonType.Text" Width="220px" Height="32px" />
                         <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="180px" Class="rounded" />

--- a/PenguinTwitchBot/Pages/Commands/ActionCommands.razor
+++ b/PenguinTwitchBot/Pages/Commands/ActionCommands.razor
@@ -86,10 +86,12 @@
         <MudItem xs="12" md="8">
             @if (_isLoading)
             {
-                <MudPaper Class="pa-4 loading-spinner" Style="height: 80vh; display: flex; align-items: center; justify-content: center;">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="2">
-                        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                        <MudText Typo="Typo.h6" Color="Color.Secondary">Loading commands...</MudText>
+                <MudPaper Class="pa-4 loading-spinner" Style="height: 80vh; overflow-y: auto;">
+                    <MudStack Spacing="3">
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="220px" Height="32px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="180px" Class="rounded" />
+                        <MudDivider />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="320px" Class="rounded" />
                     </MudStack>
                 </MudPaper>
             }

--- a/PenguinTwitchBot/Pages/Commands/AudioCommandsModern.razor
+++ b/PenguinTwitchBot/Pages/Commands/AudioCommandsModern.razor
@@ -86,10 +86,12 @@
         <MudItem xs="12" md="8">
             @if (_isLoading)
             {
-                <MudPaper Class="pa-4" Style="height: 80vh; display: flex; align-items: center; justify-content: center;">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="2">
-                        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                        <MudText Typo="Typo.h6" Color="Color.Secondary">Loading audio commands...</MudText>
+                <MudPaper Class="pa-4" Style="height: 80vh; overflow-y: auto;">
+                    <MudStack Spacing="3">
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="240px" Height="32px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="180px" Class="rounded" />
+                        <MudDivider />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="280px" Class="rounded" />
                     </MudStack>
                 </MudPaper>
             }

--- a/PenguinTwitchBot/Pages/Commands/Keywords.razor
+++ b/PenguinTwitchBot/Pages/Commands/Keywords.razor
@@ -90,10 +90,12 @@
         <MudItem xs="12" md="8">
             @if (_isLoading)
             {
-                <MudPaper Class="pa-4" Style="height: 80vh; display: flex; align-items: center; justify-content: center;">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="2">
-                        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                        <MudText Typo="Typo.h6" Color="Color.Secondary">Loading keywords...</MudText>
+                <MudPaper Class="pa-4" Style="height: 80vh; overflow-y: auto;">
+                    <MudStack Spacing="3">
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="210px" Height="32px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="180px" Class="rounded" />
+                        <MudDivider />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="320px" Class="rounded" />
                     </MudStack>
                 </MudPaper>
             }

--- a/PenguinTwitchBot/Pages/Fishing/FishingHelp.razor
+++ b/PenguinTwitchBot/Pages/Fishing/FishingHelp.razor
@@ -74,7 +74,7 @@
                                 <strong>3-Star Fish</strong>
                             </MudText>
                             <MudText Typo="Typo.caption">
-                                • @(helpData.Gold.GoldRangePerStar.TryGetValue(3, out var g3) ? g3 : "1.25–1.41x base gold")<br/>
+                                • @(helpData.Gold.GoldRangePerStar.TryGetValue(3, out var g3) ? g3 : "1.25-1.41x base gold")<br/>
                                 • Weight multiplier: @(helpData.StarWeight.WeightMultiplierPerStar.TryGetValue(3, out var w3) ? $"{w3:F1}x" : "1.5x")<br/>
                                 • Perfect quality catch!
                             </MudText>
@@ -87,7 +87,7 @@
                                 <strong>2-Star Fish</strong>
                             </MudText>
                             <MudText Typo="Typo.caption">
-                                • @(helpData.Gold.GoldRangePerStar.TryGetValue(2, out var g2) ? g2 : "1.0–1.25x base gold")<br/>
+                                • @(helpData.Gold.GoldRangePerStar.TryGetValue(2, out var g2) ? g2 : "1.0-1.25x base gold")<br/>
                                 • Weight multiplier: @(helpData.StarWeight.WeightMultiplierPerStar.TryGetValue(2, out var w2) ? $"{w2:F1}x" : "1.2x")<br/>
                                 • Good quality catch
                             </MudText>
@@ -100,7 +100,7 @@
                                 <strong>1-Star Fish</strong>
                             </MudText>
                             <MudText Typo="Typo.caption">
-                                • @(helpData.Gold.GoldRangePerStar.TryGetValue(1, out var g1) ? g1 : "0.75–1.0x base gold")<br/>
+                                • @(helpData.Gold.GoldRangePerStar.TryGetValue(1, out var g1) ? g1 : "0.75-1.0x base gold")<br/>
                                 • Weight multiplier: @(helpData.StarWeight.WeightMultiplierPerStar.TryGetValue(1, out var w1) ? $"{w1:F1}x" : "1.0x")<br/>
                                 • Standard catch
                             </MudText>

--- a/PenguinTwitchBot/Pages/Fishing/FishingInventory.razor
+++ b/PenguinTwitchBot/Pages/Fishing/FishingInventory.razor
@@ -51,9 +51,16 @@
 
         @if (isLoading)
         {
-            <MudStack AlignItems="AlignItems.Center" Spacing="3" Class="pa-6">
-                <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                <MudText Typo="Typo.body1" Color="Color.Secondary">Loading inventory...</MudText>
+            <MudStack Spacing="3" Class="pa-2">
+                <MudGrid Spacing="2">
+                    @for (var index = 0; index < 4; index++)
+                    {
+                        <MudItem xs="12" sm="6" md="4" lg="3">
+                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="120px" Class="rounded" />
+                        </MudItem>
+                    }
+                </MudGrid>
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="220px" Class="rounded" />
             </MudStack>
         }
         else

--- a/PenguinTwitchBot/Pages/Fishing/FishingLeaderboard.razor
+++ b/PenguinTwitchBot/Pages/Fishing/FishingLeaderboard.razor
@@ -21,11 +21,16 @@
 
         @if (isInitialLoading)
         {
-            <MudPaper Elevation="4" Class="pa-8">
-                <MudStack AlignItems="AlignItems.Center" Spacing="4">
-                    <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                    <MudText Typo="Typo.h6" Color="Color.Secondary">Loading fishing leaderboards...</MudText>
-                    <MudText Typo="Typo.body2" Color="Color.Secondary">Please wait while we fetch the data</MudText>
+            <MudPaper Elevation="4" Class="pa-4 pa-md-6">
+                <MudStack Spacing="4">
+                    <MudStack Row="true" Spacing="2" Class="flex-wrap">
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="170px" Height="40px" Class="rounded-pill" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="160px" Height="40px" Class="rounded-pill" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="130px" Height="40px" Class="rounded-pill" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="150px" Height="40px" Class="rounded-pill" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="150px" Height="40px" Class="rounded-pill" />
+                    </MudStack>
+                    @LeaderboardTableSkeleton(true, 5)
                 </MudStack>
             </MudPaper>
         }
@@ -52,10 +57,7 @@
                     </MudStack>
                     @if (isLoadingValuableCatches)
                     {
-                        <MudStack AlignItems="AlignItems.Center" Spacing="3" Class="pa-6">
-                            <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                            <MudText Typo="Typo.body1" Color="Color.Secondary">Loading valuable catches...</MudText>
-                        </MudStack>
+                        @LeaderboardTableSkeleton(true, 6)
                     }
                     else if (valuableCatchesLeaderboard.Any())
                     {
@@ -167,9 +169,16 @@
                         </MudStack>
                         @if (isLoadingFishLeaderboard)
                         {
-                            <MudStack AlignItems="AlignItems.Center" Spacing="3" Class="pa-6">
-                                <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                                <MudText Typo="Typo.body1" Color="Color.Secondary">Loading leaderboard...</MudText>
+                            <MudStack Spacing="4" Class="pa-2">
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="56px" Class="rounded" />
+                                <MudPaper Elevation="1" Class="pa-5 mb-2">
+                                    <MudStack Spacing="2" AlignItems="AlignItems.Center">
+                                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="150px" Height="150px" Class="rounded-lg" />
+                                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="180px" Height="36px" />
+                                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="110px" Height="32px" Class="rounded-pill" />
+                                    </MudStack>
+                                </MudPaper>
+                                @LeaderboardTableSkeleton(false, 5)
                             </MudStack>
                         }
                         else if (leaderboardFishTypes.Any())
@@ -309,10 +318,7 @@
                         </MudStack>
                         @if (isLoadingGoldLeaderboard)
                         {
-                            <MudStack AlignItems="AlignItems.Center" Spacing="3" Class="pa-6">
-                                <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                                <MudText Typo="Typo.body1" Color="Color.Secondary">Loading gold leaderboard...</MudText>
-                            </MudStack>
+                            @LeaderboardTableSkeleton(false, 6)
                         }
                         else if (goldLeaderboard.Any())
                         {
@@ -372,10 +378,7 @@
                         </MudStack>
                         @if (isLoadingSnapLossLeaderboard)
                         {
-                            <MudStack AlignItems="AlignItems.Center" Spacing="3" Class="pa-6">
-                                <MudProgressCircular Color="Color.Error" Size="Size.Large" Indeterminate="true" />
-                                <MudText Typo="Typo.body1" Color="Color.Secondary">Loading wall of shame...</MudText>
-                            </MudStack>
+                            @LeaderboardTableSkeleton(false, 6)
                         }
                         else if (snapLossLeaderboard.Any())
                         {
@@ -457,10 +460,7 @@
                             </MudStack>
                             @if (isLoadingRecentCatches)
                             {
-                                <MudStack AlignItems="AlignItems.Center" Spacing="3" Class="pa-6">
-                                    <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                                    <MudText Typo="Typo.body1" Color="Color.Secondary">Loading recent catches...</MudText>
-                                </MudStack>
+                                @LeaderboardTableSkeleton(true, 6)
                             }
                             else if (recentCatches.Any())
                             {
@@ -574,9 +574,20 @@
 
                         @if (isLoadingDex)
                         {
-                            <MudStack AlignItems="AlignItems.Center" Spacing="3" Class="pa-6">
-                                <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                                <MudText Typo="Typo.body1" Color="Color.Secondary">Loading your fish collection...</MudText>
+                            <MudStack Spacing="3" Class="pa-2">
+                                <MudStack Row="true" Spacing="2" AlignItems="AlignItems.Center" Class="mb-2 flex-wrap">
+                                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="220px" Height="44px" Class="rounded" />
+                                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="160px" Height="36px" Class="rounded" />
+                                </MudStack>
+                                <MudGrid Spacing="2">
+                                    @for (var index = 0; index < 8; index++)
+                                    {
+                                        <MudItem xs="12" sm="6" md="4" lg="3">
+                                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="360px" Class="rounded" />
+                                        </MudItem>
+                                    }
+                                </MudGrid>
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="110px" Class="rounded" />
                             </MudStack>
                         }
                         else if (fishTypes.Any())
@@ -798,6 +809,39 @@
     private IJSObjectReference? signalRModule;
     private DotNetObjectReference<FishingLeaderboard>? dotNetReference;
     private bool _hasSetupSignalR = false;
+
+    private RenderFragment LeaderboardTableSkeleton(bool includeImageColumn, int rowCount) =>
+        @<MudStack Spacing="3" Class="pa-2">
+            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="48px" Class="rounded" />
+            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="px-2 flex-wrap">
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="52px" />
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="140px" />
+                @if (includeImageColumn)
+                {
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="56px" />
+                }
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="110px" />
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="90px" />
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="90px" />
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" />
+            </MudStack>
+            @for (var index = 0; index < rowCount; index++)
+            {
+                <MudPaper Elevation="0" Outlined="true" Class="pa-3">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="flex-wrap">
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="48px" Height="26px" Class="rounded-pill" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="140px" />
+                        @if (includeImageColumn)
+                        {
+                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="50px" Height="50px" Class="rounded" />
+                        }
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="120px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="90px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="100px" />
+                    </MudStack>
+                </MudPaper>
+            }
+        </MudStack>;
 
     protected override async Task OnInitializedAsync()
     {

--- a/PenguinTwitchBot/Pages/Fishing/FishingShop.razor
+++ b/PenguinTwitchBot/Pages/Fishing/FishingShop.razor
@@ -50,9 +50,17 @@
 
         @if (isLoading)
         {
-            <MudStack AlignItems="AlignItems.Center" Spacing="3" Class="pa-6">
-                <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                <MudText Typo="Typo.body1" Color="Color.Secondary">Loading shop items...</MudText>
+            <MudStack Spacing="3" Class="pa-2">
+                <MudGrid Spacing="2">
+                    @for (var index = 0; index < 4; index++)
+                    {
+                        <MudItem xs="12" sm="6" md="3">
+                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="44px" Class="rounded" />
+                        </MudItem>
+                    }
+                </MudGrid>
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="28%" Height="28px" />
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="260px" Class="rounded" />
             </MudStack>
         }
         else if (shopItems.Any(i => i.Enabled))

--- a/PenguinTwitchBot/Pages/MusicPlayer.razor
+++ b/PenguinTwitchBot/Pages/MusicPlayer.razor
@@ -19,16 +19,26 @@
         </MudText>
 
         <MudGrid Spacing="3">
-            @if (currentSong != null)
-            {
-                <MudItem xs="12" md="4">
-                    <MudPaper Elevation="3" Class="pa-4">
-                        <MudStack Spacing="2">
-                            <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                                <MudIcon Icon="@Icons.Material.Filled.PlayCircle" Color="Color.Success" Size="Size.Large" />
-                                <MudText Typo="Typo.h6" Color="Color.Success">Now Playing</MudText>
+            <MudItem xs="12" md="4">
+                <MudPaper Elevation="3" Class="pa-4">
+                    <MudStack Spacing="2">
+                        <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                            <MudIcon Icon="@Icons.Material.Filled.PlayCircle" Color="Color.Success" Size="Size.Large" />
+                            <MudText Typo="Typo.h6" Color="Color.Success">Now Playing</MudText>
+                        </MudStack>
+                        <MudDivider />
+                        @if (!currentSongLoaded)
+                        {
+                            <MudStack Spacing="2">
+                                <MudSkeleton SkeletonType="SkeletonType.Text" Width="85%" Height="28px" />
+                                <MudSkeleton SkeletonType="SkeletonType.Text" Width="70%" />
+                                <MudSkeleton SkeletonType="SkeletonType.Text" Width="40%" />
+                                <MudDivider />
+                                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="36px" Class="rounded" />
                             </MudStack>
-                            <MudDivider />
+                        }
+                        else if (currentSong != null)
+                        {
                             <MudStack Spacing="1">
                                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                                     <MudIcon Icon="@Icons.Material.Filled.MusicNote" Size="Size.Small" Color="Color.Primary" />
@@ -56,10 +66,16 @@
                                     Steal Song
                                 </MudButton>
                             }
-                        </MudStack>
-                    </MudPaper>
-                </MudItem>
-            }
+                        }
+                        else
+                        {
+                            <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.MusicOff">
+                                No song is currently playing.
+                            </MudAlert>
+                        }
+                    </MudStack>
+                </MudPaper>
+            </MudItem>
             <MudItem xs="12" md="8">
                 <MudPaper Elevation="3" Class="pa-4" Style="height: 450px;">
                     <div id="player" style="height: 410px;"></div>
@@ -179,6 +195,7 @@
     private bool playerReady;
     private bool apiReady;
     private bool playerCreated;
+    private bool currentSongLoaded;
 
 
     protected override async Task OnInitializedAsync()
@@ -188,6 +205,7 @@
         currentSong = YtPlayer.GetCurrentSong();
         defaultPlaylistId = await YtPlayer.GetDefaultPlaylistId();
         additionalPlaylistIds = await YtPlayer.GetAdditionalPlaylistIds();
+        currentSongLoaded = currentSong != null;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -219,11 +237,16 @@
                         currentSong = YtPlayer.GetCurrentSong();
                     }
 
+                    currentSongLoaded = true;
+                    await InvokeAsync(StateHasChanged);
+
                     _timer?.Dispose();
                 }
             }
             catch (Exception)
             {
+                currentSongLoaded = true;
+                _ = InvokeAsync(StateHasChanged);
                 _timer?.Dispose();
             }
         }, null, TimeSpan.Zero, TimeSpan.FromMilliseconds(500));
@@ -244,6 +267,7 @@
         hubConnection.On<Song?>("CurrentSongUpdate", (song) =>
         {
             currentSong = song;
+            currentSongLoaded = true;
             InvokeAsync(StateHasChanged);
         });
 
@@ -262,10 +286,8 @@
         await hubConnection.StartWithExpectedExceptionHandlingAsync(logger, Snackbar, _hubConnectionCts.Token);
 
         currentSong = YtPlayer.GetCurrentSong();
-        if (currentSong != null)
-        {
-            StateHasChanged();
-        }
+        currentSongLoaded = true;
+        StateHasChanged();
     }
 
     private async Task SetDefaultPlaylist(MusicPlaylist musicPlaylist)

--- a/PenguinTwitchBot/Pages/PointGameSettings/GameSettingsPanel.razor
+++ b/PenguinTwitchBot/Pages/PointGameSettings/GameSettingsPanel.razor
@@ -7,7 +7,11 @@
 
 @if (_loading)
 {
-    <MudProgressCircular Indeterminate="true" Class="ma-4" />
+    <MudStack Spacing="3">
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="140px" Class="rounded" />
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="220px" Class="rounded" />
+        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="180px" Height="36px" Class="rounded" />
+    </MudStack>
 }
 else
 {

--- a/PenguinTwitchBot/Pages/ViewerViews/AudioCommands.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/AudioCommands.razor
@@ -13,14 +13,17 @@
         <MudPaper Elevation="3">
             @if (!dataLoaded)
             {
-                <MudOverlay Visible="!dataLoaded" DarkBackground="true" Absolute="true">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="2">
-                        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                        <MudText Typo="Typo.h6">Loading audio commands...</MudText>
-                    </MudStack>
-                </MudOverlay>
+                <MudStack Class="pa-4" Spacing="2">
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="35%" Height="28px" />
+                    <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="44px" Class="rounded" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="100%" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="92%" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="96%" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="88%" />
+                </MudStack>
             }
-
+            else
+            {
             <MudTable Items="@commands" Filter="new Func<CommandModel,bool>(FilterFunc1)" Dense="true" Hover="true">
                 <ToolBarContent>
                     <MudIcon Icon="@Icons.Material.Filled.AudioFile" Color="Color.Primary" Class="mr-2" />
@@ -110,6 +113,7 @@
                     <MudTablePager />
                 </PagerContent>
             </MudTable>
+            }
         </MudPaper>
     </MudStack>
 </MudContainer>

--- a/PenguinTwitchBot/Pages/ViewerViews/Commands.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Commands.razor
@@ -23,14 +23,21 @@
         <MudPaper Elevation="3">
             @if(!dataLoaded)
             {
-                <MudOverlay Visible="!dataLoaded" DarkBackground="true" Absolute="true">
-                    <MudStack AlignItems="AlignItems.Center" Spacing="2">
-                        <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                        <MudText Typo="Typo.h6">Loading commands...</MudText>
+                <MudStack Class="pa-4" Spacing="2">
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="30%" Height="28px" />
+                    <MudStack Row="true" Spacing="2" Class="flex-wrap">
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="200px" Height="44px" Class="rounded" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="180px" Height="36px" Class="rounded" />
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="250px" Height="44px" Class="rounded" />
                     </MudStack>
-                </MudOverlay>
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="100%" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="95%" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="97%" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="90%" />
+                </MudStack>
             }
-
+            else
+            {
             <MudTable Items="@originalCommands" Filter="new Func<CommandModel,bool>(FilterFunc1)" Dense="true" Hover="true">
                 <ToolBarContent>
                     <MudIcon Icon="@Icons.Material.Filled.ChatBubble" Color="Color.Primary" Class="mr-2" />
@@ -158,6 +165,7 @@
                     <MudTablePager />
                 </PagerContent>
             </MudTable>
+            }
         </MudPaper>
     </MudStack>
 </MudContainer>

--- a/PenguinTwitchBot/Pages/ViewerViews/Components/BonusTickets.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Components/BonusTickets.razor
@@ -22,10 +22,10 @@
         <MudDivider />
         @if (!dataLoaded)
         {
-            <MudOverlay Visible="!dataLoaded" DarkBackground="true" Absolute="true">
-                <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
-            </MudOverlay>
-            <MudSkeleton Height="80px" />
+            <MudStack Spacing="2">
+                <MudSkeleton SkeletonType="SkeletonType.Text" Width="85%" Height="28px" />
+                <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="100%" Height="56px" Class="rounded" />
+            </MudStack>
         }
         else 
         {
@@ -142,6 +142,7 @@
             disabled = await bonusTickets.DidUserRedeemBonus(Username);
         }
         StreamOnline = serviceBackbone.IsOnline;
+        dataLoaded = true;
         if (!_disposed)
         {
             StateHasChanged();
@@ -158,9 +159,6 @@
         }
 
         await EnsureHubConnectionAsync();
-
-        dataLoaded = true;
-        StateHasChanged();
     }
 
     private async Task EnsureHubConnectionAsync()

--- a/PenguinTwitchBot/Pages/ViewerViews/Components/SongRequests.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Components/SongRequests.razor
@@ -26,9 +26,6 @@
         @if (!dataLoaded)
         {
             <MudSkeleton Height="200px" />
-            <MudOverlay Visible="!dataLoaded" DarkBackground="true" Absolute="true">
-                <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
-            </MudOverlay>
         }
         else if (!songRequests.Any())
         {

--- a/PenguinTwitchBot/Pages/ViewerViews/Components/StreamSchedule.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Components/StreamSchedule.razor
@@ -10,9 +10,6 @@
         @if (!dataLoaded)
         {
             <MudSkeleton Height="200px" />
-            <MudOverlay Visible="!dataLoaded" DarkBackground="true" Absolute="true">
-                <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
-            </MudOverlay>
         }
         else if (!scheduledStreams.Any())
         {

--- a/PenguinTwitchBot/Pages/ViewerViews/Components/StreamSchedule.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Components/StreamSchedule.razor
@@ -7,11 +7,7 @@
             <MudText Typo="Typo.h5" class="mud-contrast-text">Stream Schedule</MudText>
         </MudStack>
         <MudDivider />
-        @if (!dataLoaded)
-        {
-            <MudSkeleton Height="200px" />
-        }
-        else if (!scheduledStreams.Any())
+        @if (!scheduledStreams.Any())
         {
             <MudAlert Severity="Severity.Info" Variant="Variant.Text" Icon="@Icons.Material.Filled.CalendarToday">
                 No upcoming streams scheduled yet. Check back soon!
@@ -41,17 +37,9 @@
 </MudPaper>
 @code {
     private List<ScheduledStream> scheduledStreams = new();
-    private bool dataLoaded = false;
 
     protected override async Task OnInitializedAsync()
     {
         scheduledStreams = (await schedule.GetNextStreams()).Take(5).ToList();
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender == false) return;
-        dataLoaded = true;
-        await InvokeAsync(StateHasChanged);
     }
 }

--- a/PenguinTwitchBot/Pages/ViewerViews/Components/TopRequestedSongs.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Components/TopRequestedSongs.razor
@@ -4,11 +4,7 @@
 @inject ILogger<SongRequests> logger
 
 <MudPaper Class="pa-5" Elevation="3">
-    @if(!dataLoaded)
-    {
-        <MudSkeleton Height="200px" />
-    } else {
-        <MudTable ServerData="HistoryReload" Dense="true" Hover="true" Elevation="0" @ref=historyTable>
+    <MudTable ServerData="HistoryReload" Dense="true" Hover="true" Elevation="0" @ref=historyTable>
             <ToolBarContent>
                 <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
                     <MudIcon Icon="@Icons.Material.Filled.TrendingUp" Color="Color.Success" Size="Size.Large" />
@@ -70,10 +66,25 @@
                 </MudAlert>
             </NoRecordsContent>
             <LoadingContent>
-                <MudStack Class="pa-4" Spacing="1">
-                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="100%" />
-                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="90%" />
-                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="95%" />
+                <MudStack Class="pa-4" Spacing="2">
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="flex-wrap">
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="48px" Height="24px" Class="rounded-pill" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="160px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="90px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="100px" />
+                    </MudStack>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="flex-wrap">
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="48px" Height="24px" Class="rounded-pill" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="150px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="84px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="92px" />
+                    </MudStack>
+                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2" Class="flex-wrap">
+                        <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="48px" Height="24px" Class="rounded-pill" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="170px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="88px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="96px" />
+                    </MudStack>
                 </MudStack>
             </LoadingContent>
             <PagerContent>
@@ -82,8 +93,7 @@
                     <MudTablePager />
                 }
             </PagerContent>
-        </MudTable>
-    }
+    </MudTable>
 </MudPaper>
 
 @code {
@@ -98,8 +108,6 @@
 
     [Parameter]
     public int Months { get; set; } = 3;
-
-    private bool dataLoaded = false;
 
 
     private async Task<TableData<Database.Bot.Models.Metrics.SongRequestHistoryWithRank>> HistoryReload(TableState state, CancellationToken _)
@@ -124,13 +132,6 @@
     private string GetYoutubeLink(string songId)
     {
         return $"https://youtu.be/{songId}";
-    }
-
-    protected override async Task OnAfterRenderAsync(bool firstRender)
-    {
-        if (firstRender == false) return;
-        dataLoaded = true;
-        await InvokeAsync(StateHasChanged);
     }
 
     protected override void OnParametersSet()

--- a/PenguinTwitchBot/Pages/ViewerViews/Components/TopRequestedSongs.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Components/TopRequestedSongs.razor
@@ -7,9 +7,6 @@
     @if(!dataLoaded)
     {
         <MudSkeleton Height="200px" />
-        <MudOverlay Visible="!dataLoaded" DarkBackground="true" Absolute="true">
-            <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
-        </MudOverlay>
     } else {
         <MudTable ServerData="HistoryReload" Dense="true" Hover="true" Elevation="0" @ref=historyTable>
             <ToolBarContent>
@@ -73,7 +70,11 @@
                 </MudAlert>
             </NoRecordsContent>
             <LoadingContent>
-                <MudProgressCircular Color="Color.Primary" Indeterminate="true" />
+                <MudStack Class="pa-4" Spacing="1">
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="100%" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="90%" />
+                    <MudSkeleton SkeletonType="SkeletonType.Text" Width="95%" />
+                </MudStack>
             </LoadingContent>
             <PagerContent>
                 @if (!IsPreview)

--- a/PenguinTwitchBot/Pages/ViewerViews/Quotes.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Quotes.razor
@@ -17,14 +17,17 @@
                 <MudPaper Elevation="3">
                     @if (!dataLoaded)
                     {
-                        <MudOverlay Visible="!dataLoaded" DarkBackground="true" Absolute="true">
-                            <MudStack AlignItems="AlignItems.Center" Spacing="2">
-                                <MudProgressCircular Color="Color.Primary" Size="Size.Large" Indeterminate="true" />
-                                <MudText Typo="Typo.h6">Loading quotes...</MudText>
-                            </MudStack>
-                        </MudOverlay>
+                        <MudStack Class="pa-4" Spacing="2">
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="22%" Height="28px" />
+                            <MudSkeleton SkeletonType="SkeletonType.Rectangle" Width="250px" Height="44px" Class="rounded" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="100%" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="94%" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="98%" />
+                            <MudSkeleton SkeletonType="SkeletonType.Text" Width="91%" />
+                        </MudStack>
                     }
-
+                    else
+                    {
                     <MudTable Items="@items" Filter="new Func<FilteredQuoteType,bool>(FilterFunc1)" Dense="true" Hover="true">
                         <ToolBarContent>
                             <MudIcon Icon="@Icons.Material.Filled.FormatQuote" Color="Color.Primary" Class="mr-2" />
@@ -87,6 +90,7 @@
                             <MudTablePager />
                         </PagerContent>
                     </MudTable>
+                    }
                 </MudPaper>
             </MudStack>
         </MudContainer>

--- a/PenguinTwitchBot/Pages/ViewerViews/SongRequests.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/SongRequests.razor
@@ -17,15 +17,23 @@
             Song Requests
         </MudText>
 
-        @if (currentSong != null)
-        {
-            <MudPaper Elevation="3" Class="pa-4">
-                <MudStack Spacing="2">
-                    <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
-                        <MudIcon Icon="@Icons.Material.Filled.PlayCircle" Color="Color.Success" Size="Size.Large" />
-                        <MudText Typo="Typo.h6" Color="Color.Success">Now Playing</MudText>
+        <MudPaper Elevation="3" Class="pa-4">
+            <MudStack Spacing="2">
+                <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="2">
+                    <MudIcon Icon="@Icons.Material.Filled.PlayCircle" Color="Color.Success" Size="Size.Large" />
+                    <MudText Typo="Typo.h6" Color="Color.Success">Now Playing</MudText>
+                </MudStack>
+                <MudDivider />
+                @if (!currentSongLoaded)
+                {
+                    <MudStack Spacing="2">
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="85%" Height="28px" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="70%" />
+                        <MudSkeleton SkeletonType="SkeletonType.Text" Width="40%" />
                     </MudStack>
-                    <MudDivider />
+                }
+                else if (currentSong != null)
+                {
                     <MudStack Spacing="1">
                         <MudStack Row="true" AlignItems="AlignItems.Center" Spacing="1">
                             <MudIcon Icon="@Icons.Material.Filled.MusicNote" Size="Size.Small" />
@@ -40,15 +48,15 @@
                             <MudText Typo="Typo.body2">@currentSong.Duration</MudText>
                         </MudStack>
                     </MudStack>
-                </MudStack>
-            </MudPaper>
-        }
-        else
-        {
-            <MudAlert Severity="Severity.Info" Variant="Variant.Filled" Icon="@Icons.Material.Filled.Info">
-                No song is currently playing
-            </MudAlert>
-        }
+                }
+                else
+                {
+                    <MudAlert Severity="Severity.Info" Variant="Variant.Outlined" Icon="@Icons.Material.Filled.MusicOff">
+                        No song is currently playing.
+                    </MudAlert>
+                }
+            </MudStack>
+        </MudPaper>
 
         <MudGrid Spacing="3">
             <MudItem xs="12" sm="6">
@@ -71,10 +79,12 @@
     private Song? currentSong;
     private HubConnection? hubConnection;
     private CancellationTokenSource? _hubConnectionCts;
+    private bool currentSongLoaded;
 
     protected override void OnInitialized()
     {
         currentSong = YtPlayer.GetCurrentSong();
+        currentSongLoaded = currentSong != null;
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -99,10 +109,15 @@
         hubConnection.On<Song?>("CurrentSongUpdate", (song) =>
         {
             currentSong = song;
+            currentSongLoaded = true;
             InvokeAsync(StateHasChanged);
         });
 
         await hubConnection.StartWithExpectedExceptionHandlingAsync(logger, Snackbar, _hubConnectionCts.Token);
+
+        currentSong = YtPlayer.GetCurrentSong();
+        currentSongLoaded = true;
+        StateHasChanged();
     }
 
     public async ValueTask DisposeAsync()

--- a/PenguinTwitchBot/Shared/MainLayout.razor
+++ b/PenguinTwitchBot/Shared/MainLayout.razor
@@ -21,62 +21,51 @@
 <MudDialogProvider />
 <MudSnackbarProvider />
 <MudLayout>
-    @if(!dataLoaded)
-    {
-        <MudMainContent>
-        <MudOverlay Visible="!dataLoaded" DarkBackground="true" Absolute="true">
-            <MudProgressCircular Color="Color.Secondary" Indeterminate="true" />
-        </MudOverlay>
-        </MudMainContent>
-    }
-    else 
-    {
-        <MudAppBar>
-            <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start"
-            OnClick="@((e) => DrawerToggle())" />
-            @(AppConfiguration["ApplicationTitle"] ?? "Penguin Twitch Bot")
-            <MudSpacer />
-            @if(StreamOnline)
-            {
-                <MudAlert Severity="Severity.Success" NoIcon="true">Stream is Online</MudAlert>
-            }
-            else
-            {
-                <MudAlert Severity="Severity.Error" NoIcon="true">Stream is Offline</MudAlert>
-            }
-            <div id="components-reconnect-modal" class="components-reconnect-hide">
+    <MudAppBar>
+        <MudIconButton Icon="@Icons.Material.Filled.Menu" Color="Color.Inherit" Edge="Edge.Start"
+        OnClick="@((e) => DrawerToggle())" />
+        @(AppConfiguration["ApplicationTitle"] ?? "Penguin Twitch Bot")
+        <MudSpacer />
+        @if(StreamOnline)
+        {
+            <MudAlert Severity="Severity.Success" NoIcon="true">Stream is Online</MudAlert>
+        }
+        else
+        {
+            <MudAlert Severity="Severity.Error" NoIcon="true">Stream is Offline</MudAlert>
+        }
+        <div id="components-reconnect-modal" class="components-reconnect-hide">
 
-                <div class="show">
-                    <MudSpacer />
-                    <MudAlert Severity="Severity.Warning" NoIcon="true">Attempting to reconnect or manually refresh.</MudAlert>
-                </div>
-                <div class="rejected failed">
-                    <MudSpacer />
-                    <MudAlert Severity="Severity.Warning" NoIcon="true">
-                        Reconnect failed. <a href="javascript:location.reload()" style="color: var(--mud-palette-primary);">Click here to refresh</a>.
-                    </MudAlert>
-                </div>
+            <div class="show">
+                <MudSpacer />
+                <MudAlert Severity="Severity.Warning" NoIcon="true">Attempting to reconnect or manually refresh.</MudAlert>
             </div>
-            <MudSpacer />
-            <AuthorizeView>
-                <Authorized Context="Auth">
-                    <MudImage Width="48" Src="@ProfileImage" />
-                    <MudMenu Label="@Username" AnchorOrigin="Origin.CenterCenter" TransformOrigin="Origin.TopCenter">
-                        <MudMenuItem OnClick="Signout">Sign out</MudMenuItem>
-                    </MudMenu>
-                </Authorized>
-                <NotAuthorized>
-                    <MudLink OnClick="Signin">Sign In</MudLink>
-                </NotAuthorized>
-            </AuthorizeView>
-        </MudAppBar>
-        <MudDrawer @bind-Open="@_drawerOpen" Elevation="1">
-            <NavMenu />
-        </MudDrawer>
-        <MudMainContent>
-            @Body
-        </MudMainContent>
-    }
+            <div class="rejected failed">
+                <MudSpacer />
+                <MudAlert Severity="Severity.Warning" NoIcon="true">
+                    Reconnect failed. <a href="javascript:location.reload()" style="color: var(--mud-palette-primary);">Click here to refresh</a>.
+                </MudAlert>
+            </div>
+        </div>
+        <MudSpacer />
+        <AuthorizeView>
+            <Authorized Context="Auth">
+                <MudImage Width="48" Src="@ProfileImage" />
+                <MudMenu Label="@Username" AnchorOrigin="Origin.CenterCenter" TransformOrigin="Origin.TopCenter">
+                    <MudMenuItem OnClick="Signout">Sign out</MudMenuItem>
+                </MudMenu>
+            </Authorized>
+            <NotAuthorized>
+                <MudLink OnClick="Signin">Sign In</MudLink>
+            </NotAuthorized>
+        </AuthorizeView>
+    </MudAppBar>
+    <MudDrawer @bind-Open="@_drawerOpen" Elevation="1">
+        <NavMenu />
+    </MudDrawer>
+    <MudMainContent>
+        @Body
+    </MudMainContent>
 </MudLayout>
 @code {
     bool _drawerOpen = true;
@@ -88,8 +77,6 @@
     private CancellationTokenSource? _hubConnectionCts;
     [Inject]
     BlazorAppContext? BlazorAppContext { get; set; }
-
-    private bool dataLoaded = false;
 
     protected override async Task OnInitializedAsync()
     {
@@ -156,7 +143,6 @@
 
         await hubConnection.StartWithExpectedExceptionHandlingAsync(logger, Snackbar, _hubConnectionCts.Token);
 
-        dataLoaded = true;
         StateHasChanged();
     }
 

--- a/PenguinTwitchBot/Shared/NavMenu.razor
+++ b/PenguinTwitchBot/Shared/NavMenu.razor
@@ -129,10 +129,7 @@
     }
     <MudNavLink Href="/songrequests" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.QueueMusic">Song Requests</MudNavLink>
     <MudNavLink Href="/leaderboards" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Leaderboard">Leaderboards</MudNavLink>
-    @if (FeatureRuntimeCoordinator.IsEnabled(FeatureKeys.WheeledGame))
-    {
-        <MudNavLink Href="/wheelspin" Match="NavLinkMatch.Prefix" Icon="@Icons.Material.Filled.Casino">Wheel Spin</MudNavLink>
-    }
+    
     @if( FeatureRuntimeCoordinator.IsEnabled(FeatureKeys.Fishing))
     {
         <MudNavGroup Icon="@Icons.Material.Filled.Phishing" Title="Fishing" Expanded="@GetGroupExpanded("fishing", "fishing/leaderboard", "fishing/tournaments", "fishing/shop", "fishing/inventory", "fishing/help")">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Replaced loading spinners and messages across actions, timers, commands, fishing, rewards, music, settings, and viewer pages with skeleton placeholders that better reflect the expected content layout.
  * Improved “Now Playing” states to distinguish loading, active playback, and no currently playing song.
  * Updated leaderboard loading placeholders for more consistent table previews.
  * The application shell now appears immediately during initialization.

* **Bug Fixes**
  * Removed a duplicate Wheel Spin navigation entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->