### PR TITLE
Cleanup notfound warnings since overlays scan for audio files

### DIFF
--- a/PenguinTwitchBot/Shared/NotFoundItem.razor.cs
+++ b/PenguinTwitchBot/Shared/NotFoundItem.razor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Diagnostics;
+using Microsoft.AspNetCore.Http;
 
 
 namespace PenguinTwitchBot.Shared
@@ -73,7 +74,17 @@ namespace PenguinTwitchBot.Shared
 
             // StatusCodePagesWithReExecute stores the original path in this feature.
             var reExecuteFeature = httpContext.Features.Get<IStatusCodeReExecuteFeature>();
-            var originalPath = reExecuteFeature?.OriginalPath ?? httpContext.Request.Path.Value ?? string.Empty;
+            if (reExecuteFeature is null)
+            {
+                return false;
+            }
+
+            if (reExecuteFeature.OriginalStatusCode != StatusCodes.Status404NotFound)
+            {
+                return false;
+            }
+
+            var originalPath = reExecuteFeature.OriginalPath ?? string.Empty;
 
             return IsExpectedProbePath(originalPath) && IsExpectedMediaExtension(originalPath);
         }
@@ -100,10 +111,7 @@ namespace PenguinTwitchBot.Shared
 
             var reExecuteFeature = httpContext.Features.Get<IStatusCodeReExecuteFeature>();
             var originalPath = reExecuteFeature?.OriginalPath ?? httpContext.Request.Path.Value ?? string.Empty;
-            var originalQueryString = reExecuteFeature?.OriginalQueryString ?? httpContext.Request.QueryString.Value ?? string.Empty;
-
-            var target = $"{originalPath}{originalQueryString}";
-            return target.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+            return originalPath.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
         }
     }
 }

--- a/PenguinTwitchBot/Shared/NotFoundItem.razor.cs
+++ b/PenguinTwitchBot/Shared/NotFoundItem.razor.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Authorization;
+using Microsoft.AspNetCore.Diagnostics;
 
 
 namespace PenguinTwitchBot.Shared
@@ -29,7 +30,16 @@ namespace PenguinTwitchBot.Shared
                 }
             }
             var sanitizedUri = NavigationManager.Uri.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
-            Logger?.LogWarning("{user} tried to access {pageurl} which does not exist.", username, sanitizedUri);
+            var originalRequestTarget = GetOriginalRequestTarget();
+            var shouldSuppressWarning = ShouldSuppressNotFoundWarning();
+            if (shouldSuppressWarning)
+            {
+                Logger?.LogDebug("Ignored expected 404 probe for {originalTarget}. NotFound page: {pageurl}.", originalRequestTarget, sanitizedUri);
+            }
+            else
+            {
+                Logger?.LogWarning("{user} tried to access {pageurl} which does not exist. Original target: {originalTarget}.", username, sanitizedUri, originalRequestTarget);
+            }
             if (httpContextAccessor is not null)
             {
 #pragma warning disable CS8602 // Dereference of a possibly null reference.
@@ -40,6 +50,61 @@ namespace PenguinTwitchBot.Shared
 #pragma warning restore CS8602 // Dereference of a possibly null reference.
             }
             base.OnInitialized();
+        }
+
+        private bool ShouldSuppressNotFoundWarning()
+        {
+            var httpContext = httpContextAccessor?.HttpContext;
+            if (httpContext is null)
+            {
+                return false;
+            }
+
+            // StatusCodePagesWithReExecute stores the original path in this feature.
+            var reExecuteFeature = httpContext.Features.Get<IStatusCodeReExecuteFeature>();
+            var originalPath = reExecuteFeature?.OriginalPath ?? httpContext.Request.Path.Value ?? string.Empty;
+
+            if (!string.Equals(httpContext.Request.Method, "HEAD", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (!(originalPath.StartsWith("/gifs/", StringComparison.OrdinalIgnoreCase)
+                || originalPath.StartsWith("/audio/", StringComparison.OrdinalIgnoreCase)
+                || originalPath.StartsWith("/clips/", StringComparison.OrdinalIgnoreCase)
+                || originalPath.StartsWith("/fishes/", StringComparison.OrdinalIgnoreCase)))
+            {
+                return false;
+            }
+
+            var ext = Path.GetExtension(originalPath);
+            return !string.IsNullOrWhiteSpace(ext)
+                && (ext.Equals(".mp3", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".wav", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".ogg", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".oga", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".opus", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".aac", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".m4a", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".mp4", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".webm", StringComparison.OrdinalIgnoreCase)
+                    || ext.Equals(".ogv", StringComparison.OrdinalIgnoreCase));
+        }
+
+        private string GetOriginalRequestTarget()
+        {
+            var httpContext = httpContextAccessor?.HttpContext;
+            if (httpContext is null)
+            {
+                return "UnknownTarget";
+            }
+
+            var reExecuteFeature = httpContext.Features.Get<IStatusCodeReExecuteFeature>();
+            var originalPath = reExecuteFeature?.OriginalPath ?? httpContext.Request.Path.Value ?? string.Empty;
+            var originalQueryString = reExecuteFeature?.OriginalQueryString ?? httpContext.Request.QueryString.Value ?? string.Empty;
+
+            var target = $"{originalPath}{originalQueryString}";
+            return target.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
         }
     }
 }

--- a/PenguinTwitchBot/Shared/NotFoundItem.razor.cs
+++ b/PenguinTwitchBot/Shared/NotFoundItem.razor.cs
@@ -7,6 +7,12 @@ namespace PenguinTwitchBot.Shared
 {
     public partial class NotFoundItem : ComponentBase
     {
+        private static readonly string[] ExpectedProbePrefixes = ["/gifs/", "/audio/", "/clips/", "/fishes/"];
+        private static readonly HashSet<string> ExpectedMediaExtensions = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ".mp3", ".wav", ".ogg", ".oga", ".opus", ".aac", ".m4a", ".mp4", ".webm", ".ogv"
+        };
+
         [Inject]
         private ILogger<NotFoundItem>? Logger { get; set; }
         [Inject]
@@ -60,35 +66,28 @@ namespace PenguinTwitchBot.Shared
                 return false;
             }
 
+            if (!IsHeadRequest(httpContext.Request.Method))
+            {
+                return false;
+            }
+
             // StatusCodePagesWithReExecute stores the original path in this feature.
             var reExecuteFeature = httpContext.Features.Get<IStatusCodeReExecuteFeature>();
             var originalPath = reExecuteFeature?.OriginalPath ?? httpContext.Request.Path.Value ?? string.Empty;
 
-            if (!string.Equals(httpContext.Request.Method, "HEAD", StringComparison.OrdinalIgnoreCase))
-            {
-                return false;
-            }
+            return IsExpectedProbePath(originalPath) && IsExpectedMediaExtension(originalPath);
+        }
 
-            if (!(originalPath.StartsWith("/gifs/", StringComparison.OrdinalIgnoreCase)
-                || originalPath.StartsWith("/audio/", StringComparison.OrdinalIgnoreCase)
-                || originalPath.StartsWith("/clips/", StringComparison.OrdinalIgnoreCase)
-                || originalPath.StartsWith("/fishes/", StringComparison.OrdinalIgnoreCase)))
-            {
-                return false;
-            }
+        private static bool IsHeadRequest(string? method)
+            => string.Equals(method, "HEAD", StringComparison.OrdinalIgnoreCase);
 
+        private static bool IsExpectedProbePath(string originalPath)
+            => ExpectedProbePrefixes.Any(prefix => originalPath.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
+
+        private static bool IsExpectedMediaExtension(string originalPath)
+        {
             var ext = Path.GetExtension(originalPath);
-            return !string.IsNullOrWhiteSpace(ext)
-                && (ext.Equals(".mp3", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".wav", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".ogg", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".oga", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".opus", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".aac", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".m4a", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".mp4", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".webm", StringComparison.OrdinalIgnoreCase)
-                    || ext.Equals(".ogv", StringComparison.OrdinalIgnoreCase));
+            return !string.IsNullOrWhiteSpace(ext) && ExpectedMediaExtensions.Contains(ext);
         }
 
         private string GetOriginalRequestTarget()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary warning logs for expected media-file probes that return a 404.
  * Continued warning for unexpected missing resources, with clearer request-target details.
  * Added debug-level logging for recognized expected probes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->