### PR TITLE
Fix giveaway links

### DIFF
--- a/PenguinTwitchBot/Bot/Commands/Features/GiveawayFeature.cs
+++ b/PenguinTwitchBot/Bot/Commands/Features/GiveawayFeature.cs
@@ -95,6 +95,7 @@ namespace PenguinTwitchBot.Bot.Commands.Features
             await RegisterDefaultCommand("close", this, moduleName, Rank.Streamer);
             await RegisterDefaultCommand("resetdraw", this, moduleName, Rank.Streamer);
             await RegisterDefaultCommand("setprize", this, moduleName, Rank.Streamer);
+            await RegisterDefaultCommand("entries", this, moduleName);
             await pointsSystem.RegisterDefaultPointForGame(ModuleName);
             _timer.Start();
             logger.LogInformation("Registered commands for {moduleName}", moduleName);
@@ -140,7 +141,18 @@ namespace PenguinTwitchBot.Bot.Commands.Features
                         await SetPrize(e.Arg);
                         break;
                     }
+                case "entries":
+                    {
+                        await Entries(e.Name);
+                        break;
+                    }
             }
+        }
+
+        private async Task Entries(string name)
+        {
+            var entries = await GetEntriesCount(name);
+            await ServiceBackbone.SendChatMessage($"{name} has {entries} entries into the giveaway.");
         }
 
         public async Task<string> GetPrize()

--- a/PenguinTwitchBot/Pages/ViewerViews/Components/GiveawayPreview.razor
+++ b/PenguinTwitchBot/Pages/ViewerViews/Components/GiveawayPreview.razor
@@ -12,7 +12,7 @@
                 <MudIcon Icon="@Icons.Material.Filled.CardGiftcard" Color="Color.Primary" Size="Size.Large" />
                 <MudText Typo="Typo.h5" class="mud-contrast-text">Current Giveaway</MudText>
             </MudStack>
-            <MudButton Href="viewergiveaway" 
+            <MudButton Href="giveaway" 
                        Variant="Variant.Text" 
                        Color="Color.Primary" 
                        EndIcon="@Icons.Material.Filled.ArrowForward">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `entries` chat command that lets viewers check their current giveaway entry count.

* **Bug Fixes**
  * Updated the giveaway preview’s “View Details” link to open the correct giveaway page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->